### PR TITLE
Fixes for package publishing and repo usability

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Description
+
+<!-- What happened? What did you expect? -->
+
+## Steps to reproduce
+
+1.
+
+## Environment
+
+- Elixir:
+- OTP:
+- `a2a` version:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Checklist
+
+- [ ] `mix test` passes
+- [ ] `mix quality` passes
+- [ ] `bin/tck mandatory` passes (if behaviour changed)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: mix
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -167,3 +169,21 @@ jobs:
           uv run ./run_tck.py \
             --sut-url http://localhost:9999 \
             --category mandatory
+
+  publish:
+    name: Publish to Hex
+    if: github.event_name == 'release'
+    needs: [quality, test, tck]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.18"
+          otp-version: "27"
+
+      - run: mix deps.get
+      - run: mix hex.publish --organization actioncard --yes
+    env:
+      HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-03-03
+
+### Added
+
+- Automated Hex publishing to `actioncard` org on GitHub releases
+- Dependabot configuration for Mix deps and GitHub Actions
+- Issue and PR templates
+
+### Fixed
+
+- Minor doc cleanups: internal module references, typespec refinement
+
+
 ## [0.1.0] - 2026-03-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -152,11 +152,11 @@ end
 
 ## Examples
 
-The [`examples/`](examples/) directory contains runnable scripts:
+The [`examples/`](https://github.com/actioncard/a2a-elixir/tree/main/examples) directory contains runnable scripts:
 
-- **[`demo.exs`](examples/demo.exs)** — local agents: simple call, multi-turn, and streaming
-- **[`client_server.exs`](examples/client_server.exs)** — full HTTP client/server with Bandit and `A2A.Client`
-- **[`supervisor_demo.exs`](examples/supervisor_demo.exs)** — `A2A.AgentSupervisor`, registry, and skill-based routing
+- **[`demo.exs`](https://github.com/actioncard/a2a-elixir/blob/main/examples/demo.exs)** — local agents: simple call, multi-turn, and streaming
+- **[`client_server.exs`](https://github.com/actioncard/a2a-elixir/blob/main/examples/client_server.exs)** — full HTTP client/server with Bandit and `A2A.Client`
+- **[`supervisor_demo.exs`](https://github.com/actioncard/a2a-elixir/blob/main/examples/supervisor_demo.exs)** — `A2A.AgentSupervisor`, registry, and skill-based routing
 
 Run any example with:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -185,8 +185,8 @@ Discrete events:
   metadata: %{agent, task_id, from, to}
 ```
 
-Emit sites: `A2A.Agent.Runtime.process_message/4` (message span),
-`A2A.call/3` and `A2A.stream/3` (call span), `A2A.Agent.State.transition/2`
+Emit sites: `process_message/4` in Agent.Runtime (message span),
+`A2A.call/3` and `A2A.stream/3` (call span), `transition/2` in Agent.State
 (transition event).
 
 Add an `A2A.Telemetry` module documenting all events as a public API contract.

--- a/lib/a2a/agent.ex
+++ b/lib/a2a/agent.ex
@@ -41,11 +41,12 @@ defmodule A2A.Agent do
 
   - **`A2A.Agent`** (this module) — the behaviour definition and the `use`
     macro that generates GenServer client API and callbacks.
-  - **`A2A.Agent.Runtime`** — pure functions for message processing. Creates
-    tasks, calls `handle_message/2`, maps reply tuples to state transitions.
-    Also handles task continuation (multi-turn) and stream wrapping.
-  - **`A2A.Agent.State`** — the internal GenServer state struct. Holds the
-    task map, context index, and optional task store reference. Provides
+  - **Agent.Runtime** (internal) — pure functions for message processing.
+    Creates tasks, calls `handle_message/2`, maps reply tuples to state
+    transitions. Also handles task continuation (multi-turn) and stream
+    wrapping.
+  - **Agent.State** (internal) — the internal GenServer state struct. Holds
+    the task map, context index, and optional task store reference. Provides
     helpers for task storage, retrieval, and state transitions.
 
   ## Task Lifecycle

--- a/lib/a2a/agent_card.ex
+++ b/lib/a2a/agent_card.ex
@@ -4,7 +4,7 @@ defmodule A2A.AgentCard do
 
   Contains the agent's identity, capabilities, and skills as returned by
   `GET /.well-known/agent-card.json`. This is the wire-format struct used
-  by clients; server-side agents define their card via `A2A.Agent.agent_card/0`.
+  by clients; server-side agents define their card via the `agent_card/0` callback.
 
   ## Example
 

--- a/lib/a2a/jsonrpc.ex
+++ b/lib/a2a/jsonrpc.ex
@@ -56,7 +56,7 @@ defmodule A2A.JSONRPC do
 
   @type result ::
           {:reply, map()}
-          | {:stream, String.t(), map(), Request.id()}
+          | {:stream, String.t(), map(), String.t() | integer() | nil}
 
   @doc "Called for `message/send` and `message/stream` requests."
   @callback handle_send(A2A.Message.t(), params :: map(), context :: map()) ::

--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,8 @@ defmodule A2A.MixProject do
       name: "a2a",
       maintainers: ["Action Card AB"],
       licenses: ["Apache-2.0"],
-      files: ~w(lib .formatter.exs mix.exs README.md LICENSE CHANGELOG.md),
+      files:
+        ~w(lib examples .formatter.exs mix.exs README.md LICENSE CHANGELOG.md CONTRIBUTING.md SPEC.md),
       links: %{
         "GitHub" => @source_url,
         "A2A Spec" => @a2a_spec_url
@@ -73,7 +74,7 @@ defmodule A2A.MixProject do
   defp docs do
     [
       main: "A2A",
-      extras: ["README.md", "CHANGELOG.md", "LICENSE"],
+      extras: ["README.md", "CHANGELOG.md", "CONTRIBUTING.md", "SPEC.md", "LICENSE"],
       groups_for_modules: [
         Core: [~r/A2A$/],
         Storage: [~r/A2A\.TaskStore/],


### PR DESCRIPTION
## Summary

- Add publishing of hex.pm package on CI.
- Documentation fixes.
- Github usability enhancements.
- Gihtub Dependabot configuration.

## Checklist

- [x] `mix test` passes
- [x] `mix quality` passes
- [ ] `bin/tck mandatory` passes (if behaviour changed)
