### PR TITLE
Fix package version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,16 @@ jobs:
           otp-version: "27"
 
       - run: mix deps.get
+
+      - name: Verify version matches tag
+        run: |
+          tag="${GITHUB_REF#refs/tags/v}"
+          mix_version=$(grep '@version "' mix.exs | sed 's/.*@version "//;s/"//')
+          if [ "$tag" != "$mix_version" ]; then
+            echo "::error::Tag v$tag does not match mix.exs version $mix_version"
+            exit 1
+          fi
+
       - run: mix hex.publish --organization actioncard --yes
     env:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule A2A.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
   @source_url "https://github.com/actioncard/a2a-elixir"
   @a2a_spec_url "https://google.github.io/A2A/"
 


### PR DESCRIPTION
## Summary

Previously the v0.1.0 was accidentally re-published, this check should avoid it.

## Checklist

- [x] `mix test` passes
- [x] `mix quality` passes
- [ ] `bin/tck mandatory` passes (if behaviour changed)
