### PR TITLE
Don't publish to hex.pm with an organization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,6 @@ jobs:
             exit 1
           fi
 
-      - run: mix hex.publish --organization actioncard --yes
+      - run: mix hex.publish --yes
     env:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}


### PR DESCRIPTION
## Summary

The organization should not be used for the package when publishing.

## Checklist

- [x] `mix test` passes
- [x] `mix quality` passes
- [ ] `bin/tck mandatory` passes (if behaviour changed)
