### PR TITLE
feat: add v1.0 error types (ExtensionSupportRequired, VersionNotSupported)

### DIFF
--- a/lib/a2a/jsonrpc/error.ex
+++ b/lib/a2a/jsonrpc/error.ex
@@ -2,8 +2,8 @@ defmodule A2A.JSONRPC.Error do
   @moduledoc """
   JSON-RPC 2.0 error with A2A-specific error codes.
 
-  Provides a struct and named constructors for the 12 error codes defined by
-  the A2A protocol (5 standard JSON-RPC + 7 A2A-specific).
+  Provides a struct and named constructors for the 14 error codes defined by
+  the A2A protocol (5 standard JSON-RPC + 9 A2A-specific).
 
   ## Example
 
@@ -115,6 +115,26 @@ defmodule A2A.JSONRPC.Error do
     %__MODULE__{
       code: -32_007,
       message: "Authenticated Extended Card is not configured",
+      data: data
+    }
+  end
+
+  @doc "Builds an extension support required error (-32008)."
+  @spec extension_support_required(term()) :: t()
+  def extension_support_required(data \\ nil) do
+    %__MODULE__{
+      code: -32_008,
+      message: "Extension support is required",
+      data: data
+    }
+  end
+
+  @doc "Builds a version not supported error (-32009)."
+  @spec version_not_supported(term()) :: t()
+  def version_not_supported(data \\ nil) do
+    %__MODULE__{
+      code: -32_009,
+      message: "Version not supported",
       data: data
     }
   end

--- a/test/a2a/jsonrpc/error_test.exs
+++ b/test/a2a/jsonrpc/error_test.exs
@@ -79,6 +79,20 @@ defmodule A2A.JSONRPC.ErrorTest do
       assert e.message == "Authenticated Extended Card is not configured"
     end
 
+    test "extension_support_required/0" do
+      e = Error.extension_support_required()
+      assert e.code == -32_008
+      assert e.message == "Extension support is required"
+      assert e.data == nil
+    end
+
+    test "version_not_supported/0" do
+      e = Error.version_not_supported()
+      assert e.code == -32_009
+      assert e.message == "Version not supported"
+      assert e.data == nil
+    end
+
     test "constructors accept optional data" do
       e = Error.parse_error("unexpected token")
       assert e.data == "unexpected token"


### PR DESCRIPTION
Part of #13 (A2A v1.0 Protocol Support)

## Changes

Adds the two missing A2A v1.0 error type constructors to `A2A.JSONRPC.Error`:

- `extension_support_required/1` — code `-32008`
- `version_not_supported/1` — code `-32009`

Both follow the existing pattern (default data `nil`, optional `data` param).

Includes tests for both new constructors.

## Verified Error Codes

All 14 error codes verified against [`a2a.proto` HEAD](https://github.com/a2aproject/A2A/blob/main/specification/a2a.proto) (Section 5.4 Error Code Mappings):

| Constructor | Code | Status |
|---|---|---|
| `parse_error` | -32700 | ✅ |
| `invalid_request` | -32600 | ✅ |
| `method_not_found` | -32601 | ✅ |
| `invalid_params` | -32602 | ✅ |
| `internal_error` | -32603 | ✅ |
| `task_not_found` | -32001 | ✅ |
| `task_not_cancelable` | -32002 | ✅ |
| `push_notification_not_supported` | -32003 | ✅ |
| `unsupported_operation` | -32004 | ✅ |
| `content_type_not_supported` | -32005 | ✅ |
| `invalid_agent_response` | -32006 | ✅ |
| `authenticated_extended_card_not_configured` | -32007 | ✅ |
| `extension_support_required` | -32008 | ✅ **NEW** |
| `version_not_supported` | -32009 | ✅ **NEW** |

Fixes part of #13