### PR TITLE
feat: A2A extension mechanism with header negotiation

### DIFF
--- a/lib/a2a/agent_extension.ex
+++ b/lib/a2a/agent_extension.ex
@@ -1,0 +1,42 @@
+defmodule A2A.AgentExtension do
+  @moduledoc """
+  A declaration of a protocol extension supported by an Agent.
+
+  Per the A2A v1.0 spec, agents declare supported extensions in their
+  Agent Card. Extensions are identified by a URI and may be marked as
+  required, meaning clients must understand and comply with the
+  extension's requirements.
+
+  ## Fields
+
+    * `:uri` — the unique URI identifying the extension (required)
+    * `:description` — a human-readable description of how the agent uses the extension
+    * `:required` — if `true`, the client must support this extension (default: `false`)
+    * `:params` — optional extension-specific configuration parameters
+
+  ## Examples
+
+      %A2A.AgentExtension{
+        uri: "https://a2a-protocol.org/extensions/timestamp",
+        description: "Adds timestamps to messages",
+        required: false
+      }
+
+      %A2A.AgentExtension{
+        uri: "https://a2a-protocol.org/extensions/secure-passport",
+        description: "Requires secure passport for authentication",
+        required: true,
+        params: %{"version" => "1.0"}
+      }
+  """
+
+  @type t :: %__MODULE__{
+          uri: String.t(),
+          description: String.t() | nil,
+          required: boolean(),
+          params: map() | nil
+        }
+
+  @enforce_keys [:uri]
+  defstruct [:uri, :description, :params, required: false]
+end

--- a/lib/a2a/client.ex
+++ b/lib/a2a/client.ex
@@ -35,6 +35,8 @@ if Code.ensure_loaded?(Req) do
     - `:context_id` — set the context ID
     - `:configuration` — `MessageSendConfiguration` map
     - `:metadata` — arbitrary metadata map
+    - `:extensions` — list of extension URI strings; sent via
+      `A2A-Extensions` request header (set at client creation via `new/2`)
     - `:headers` — additional HTTP headers
     - `:timeout` — HTTP request timeout in ms
     """
@@ -45,10 +47,11 @@ if Code.ensure_loaded?(Req) do
 
     @type t :: %__MODULE__{
             url: String.t(),
-            req: Req.Request.t()
+            req: Req.Request.t(),
+            extensions: [String.t()]
           }
 
-    defstruct [:url, :req]
+    defstruct [:url, :req, extensions: []]
 
     @doc """
     Creates a new client struct.
@@ -69,18 +72,28 @@ if Code.ensure_loaded?(Req) do
     end
 
     def new(url, opts) when is_binary(url) do
+      {ext_uris, opts} = Keyword.pop(opts, :extensions, [])
+
       {req_opts, _rest} =
         Keyword.split(opts, [:headers, :connect_options, :retry, :plug])
+
+      headers = [{"content-type", "application/json"}]
+
+      headers =
+        case ext_uris do
+          [] -> headers
+          uris -> [{"a2a-extensions", Enum.join(uris, ", ")} | headers]
+        end
 
       req =
         Req.new(
           Keyword.merge(
-            [base_url: url, headers: [{"content-type", "application/json"}]],
+            [base_url: url, headers: headers],
             req_opts
           )
         )
 
-      %__MODULE__{url: url, req: req}
+      %__MODULE__{url: url, req: req, extensions: ext_uris}
     end
 
     @doc """
@@ -343,6 +356,32 @@ if Code.ensure_loaded?(Req) do
     defp ensure_client(%__MODULE__{} = client), do: client
     defp ensure_client(%A2A.AgentCard{} = card), do: new(card)
     defp ensure_client(url) when is_binary(url), do: new(url)
+
+    @doc """
+    Parses the `A2A-Extensions` response header from a `Req.Response`.
+
+    Returns a list of extension URI strings the server supports.
+    Returns an empty list if the header is absent.
+
+    ## Examples
+
+        {:ok, response} = Req.post(client.req, body: body)
+        server_exts = A2A.Client.parse_extensions_header(response)
+        #=> ["https://a2a-protocol.org/extensions/timestamp"]
+    """
+    @spec parse_extensions_header(Req.Response.t()) :: [String.t()]
+    def parse_extensions_header(%Req.Response{headers: headers}) do
+      case Map.get(headers, "a2a-extensions", []) do
+        [] ->
+          []
+
+        values when is_list(values) ->
+          values
+          |> Enum.flat_map(&String.split(&1, ","))
+          |> Enum.map(&String.trim/1)
+          |> Enum.reject(&(&1 == ""))
+      end
+    end
 
     # -------------------------------------------------------------------
     # Private — Response decoding

--- a/lib/a2a/jsonrpc/error.ex
+++ b/lib/a2a/jsonrpc/error.ex
@@ -119,6 +119,26 @@ defmodule A2A.JSONRPC.Error do
     }
   end
 
+  @doc "Builds an extension support required error (-32008)."
+  @spec extension_support_required(term()) :: t()
+  def extension_support_required(data \\ nil) do
+    %__MODULE__{
+      code: -32_008,
+      message: "Extension support required",
+      data: data
+    }
+  end
+
+  @doc "Builds a version not supported error (-32009)."
+  @spec version_not_supported(term()) :: t()
+  def version_not_supported(data \\ nil) do
+    %__MODULE__{
+      code: -32_009,
+      message: "Version not supported",
+      data: data
+    }
+  end
+
   @doc """
   Converts an error struct to a JSON-ready map.
 

--- a/lib/a2a/plug.ex
+++ b/lib/a2a/plug.ex
@@ -32,6 +32,12 @@ if Code.ensure_loaded?(Plug) do
     - `:metadata` — static metadata merged into every JSON-RPC call
       (default: `%{}`). Useful for deployment-level metadata like
       `%{"env" => "prod"}`. Overridden per-request by `put_metadata/2`.
+    - `:extensions` — list of `%A2A.AgentExtension{}` structs declaring
+      extensions this server supports. Required extensions are validated
+      against the client's `A2A-Extensions` request header; missing
+      required extensions return `ExtensionSupportRequiredError` (-32008).
+      The server sets the `A2A-Extensions` response header with all
+      supported extension URIs.
 
     ## Per-Request Overrides
 
@@ -116,7 +122,8 @@ if Code.ensure_loaded?(Plug) do
         agent_card_path: Keyword.get(opts, :agent_card_path, [".well-known", "agent-card.json"]),
         json_rpc_path: Keyword.get(opts, :json_rpc_path, []),
         agent_card_opts: Keyword.get(opts, :agent_card_opts, []),
-        metadata: Keyword.get(opts, :metadata, %{})
+        metadata: Keyword.get(opts, :metadata, %{}),
+        extensions: Keyword.get(opts, :extensions, [])
       }
     end
 
@@ -129,7 +136,23 @@ if Code.ensure_loaded?(Plug) do
 
     def call(%{method: "POST", path_info: path} = conn, %{json_rpc_path: path} = opts) do
       resolved = resolve_opts(conn, opts)
-      handle_json_rpc(conn, resolved)
+
+      case validate_extensions(conn, resolved) do
+        :ok ->
+          conn
+          |> put_extensions_response_header(resolved)
+          |> handle_json_rpc(resolved)
+
+        {:error, missing} ->
+          error =
+            Error.extension_support_required(
+              "Client missing required extensions: #{Enum.join(missing, ", ")}"
+            )
+
+          conn
+          |> put_resp_content_type("application/json")
+          |> send_resp(200, Jason.encode!(Response.error(nil, error)))
+      end
     end
 
     def call(%{path_info: path} = conn, %{agent_card_path: path}) do
@@ -140,6 +163,50 @@ if Code.ensure_loaded?(Plug) do
 
     def call(conn, _opts) do
       send_resp(conn, 404, "Not Found")
+    end
+
+    # -- Extension validation --------------------------------------------------
+
+    defp validate_extensions(_conn, %{extensions: []}), do: :ok
+
+    defp validate_extensions(conn, %{extensions: extensions}) do
+      required_uris =
+        extensions
+        |> Enum.filter(& &1.required)
+        |> Enum.map(& &1.uri)
+        |> MapSet.new()
+
+      case MapSet.size(required_uris) do
+        0 ->
+          :ok
+
+        _ ->
+          client_uris =
+            conn
+            |> get_req_header("a2a-extensions")
+            |> parse_extension_header()
+            |> MapSet.new()
+
+          missing = MapSet.difference(required_uris, client_uris) |> MapSet.to_list()
+
+          if missing == [], do: :ok, else: {:error, missing}
+      end
+    end
+
+    defp parse_extension_header([]), do: []
+
+    defp parse_extension_header([header | _]) do
+      header
+      |> String.split(",")
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+    end
+
+    defp put_extensions_response_header(conn, %{extensions: []}), do: conn
+
+    defp put_extensions_response_header(conn, %{extensions: extensions}) do
+      uris = Enum.map(extensions, & &1.uri)
+      put_resp_header(conn, "a2a-extensions", Enum.join(uris, ", "))
     end
 
     # -- Option resolution -----------------------------------------------------

--- a/test/a2a/extension_test.exs
+++ b/test/a2a/extension_test.exs
@@ -1,0 +1,276 @@
+defmodule A2A.ExtensionTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :plug
+
+  alias A2A.AgentExtension
+
+  # -- Helpers ----------------------------------------------------------------
+
+  defp plug_opts(agent, extra \\ []) do
+    A2A.Plug.init([agent: agent, base_url: "http://localhost:4000"] ++ extra)
+  end
+
+  defp json_rpc_conn(method, params \\ %{}, id \\ 1) do
+    body =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "id" => id,
+        "method" => method,
+        "params" => params
+      })
+
+    Plug.Test.conn(:post, "/", body)
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+  end
+
+  defp message_params(text \\ "hello") do
+    %{
+      "message" => %{
+        "messageId" => "msg-test",
+        "role" => "user",
+        "parts" => [%{"kind" => "text", "text" => text}]
+      }
+    }
+  end
+
+  defp json_body(conn) do
+    Jason.decode!(conn.resp_body)
+  end
+
+  defp get_resp_header(conn, key) do
+    for {k, v} <- conn.resp_headers, k == key, do: v
+  end
+
+  setup do
+    agent = start_supervised!(A2A.Test.EchoAgent)
+    {:ok, agent: agent}
+  end
+
+  # -- AgentExtension struct ---------------------------------------------------
+
+  describe "AgentExtension struct" do
+    test "creates with required fields" do
+      ext = %AgentExtension{uri: "https://example.com/ext/a"}
+      assert ext.uri == "https://example.com/ext/a"
+      assert ext.required == false
+      assert ext.description == nil
+      assert ext.params == nil
+    end
+
+    test "creates with all fields" do
+      ext = %AgentExtension{
+        uri: "https://example.com/ext/b",
+        description: "Test extension",
+        required: true,
+        params: %{"version" => "1.0"}
+      }
+
+      assert ext.uri == "https://example.com/ext/b"
+      assert ext.description == "Test extension"
+      assert ext.required == true
+      assert ext.params == %{"version" => "1.0"}
+    end
+
+    test "enforces :uri key" do
+      assert_raise ArgumentError, fn ->
+        struct!(AgentExtension, %{description: "no URI"})
+      end
+    end
+  end
+
+  # -- Extension negotiation: no extensions configured -------------------------
+
+  describe "no extensions configured" do
+    test "requests succeed without A2A-Extensions header", %{agent: agent} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> A2A.Plug.call(plug_opts(agent))
+
+      assert conn.status == 200
+      body = json_body(conn)
+      assert body["result"]["task"]["kind"] == "task"
+
+      # No A2A-Extensions response header when no extensions configured
+      assert get_resp_header(conn, "a2a-extensions") == []
+    end
+  end
+
+  # -- Extension negotiation: optional extensions only -------------------------
+
+  describe "optional extensions only" do
+    setup %{agent: agent} do
+      extensions = [
+        %AgentExtension{uri: "https://example.com/ext/timestamp", description: "Timestamps"},
+        %AgentExtension{uri: "https://example.com/ext/tracing", required: false}
+      ]
+
+      opts = plug_opts(agent, extensions: extensions)
+      {:ok, opts: opts}
+    end
+
+    test "requests succeed without A2A-Extensions header", %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> A2A.Plug.call(opts)
+
+      assert conn.status == 200
+      body = json_body(conn)
+      assert body["result"]["task"]["kind"] == "task"
+    end
+
+    test "response includes A2A-Extensions header with all supported URIs", %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> A2A.Plug.call(opts)
+
+      [header] = get_resp_header(conn, "a2a-extensions")
+      uris = String.split(header, ", ")
+      assert "https://example.com/ext/timestamp" in uris
+      assert "https://example.com/ext/tracing" in uris
+    end
+  end
+
+  # -- Extension negotiation: required extensions ------------------------------
+
+  describe "required extensions" do
+    setup %{agent: agent} do
+      extensions = [
+        %AgentExtension{
+          uri: "https://example.com/ext/passport",
+          required: true,
+          description: "Secure passport required"
+        },
+        %AgentExtension{
+          uri: "https://example.com/ext/timestamp",
+          required: false
+        }
+      ]
+
+      opts = plug_opts(agent, extensions: extensions)
+      {:ok, opts: opts}
+    end
+
+    test "returns ExtensionSupportRequiredError when client missing required extension",
+         %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> A2A.Plug.call(opts)
+
+      assert conn.status == 200
+      body = json_body(conn)
+      assert body["error"]["code"] == -32_008
+      assert body["error"]["message"] == "Extension support required"
+      assert body["error"]["data"] =~ "https://example.com/ext/passport"
+    end
+
+    test "succeeds when client declares required extension", %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> Plug.Conn.put_req_header(
+          "a2a-extensions",
+          "https://example.com/ext/passport"
+        )
+        |> A2A.Plug.call(opts)
+
+      assert conn.status == 200
+      body = json_body(conn)
+      assert body["result"]["task"]["kind"] == "task"
+    end
+
+    test "succeeds when client declares multiple extensions including required", %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> Plug.Conn.put_req_header(
+          "a2a-extensions",
+          "https://example.com/ext/passport, https://example.com/ext/other"
+        )
+        |> A2A.Plug.call(opts)
+
+      assert conn.status == 200
+      body = json_body(conn)
+      assert body["result"]["task"]["kind"] == "task"
+    end
+
+    test "response includes all supported extension URIs in header", %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> Plug.Conn.put_req_header(
+          "a2a-extensions",
+          "https://example.com/ext/passport"
+        )
+        |> A2A.Plug.call(opts)
+
+      [header] = get_resp_header(conn, "a2a-extensions")
+      uris = String.split(header, ", ")
+      assert "https://example.com/ext/passport" in uris
+      assert "https://example.com/ext/timestamp" in uris
+    end
+  end
+
+  # -- Extension negotiation: multiple required extensions ---------------------
+
+  describe "multiple required extensions" do
+    setup %{agent: agent} do
+      extensions = [
+        %AgentExtension{uri: "https://example.com/ext/a", required: true},
+        %AgentExtension{uri: "https://example.com/ext/b", required: true}
+      ]
+
+      opts = plug_opts(agent, extensions: extensions)
+      {:ok, opts: opts}
+    end
+
+    test "fails when client only declares one of two required extensions", %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> Plug.Conn.put_req_header("a2a-extensions", "https://example.com/ext/a")
+        |> A2A.Plug.call(opts)
+
+      body = json_body(conn)
+      assert body["error"]["code"] == -32_008
+      assert body["error"]["data"] =~ "https://example.com/ext/b"
+    end
+
+    test "succeeds when client declares both required extensions", %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> Plug.Conn.put_req_header(
+          "a2a-extensions",
+          "https://example.com/ext/a, https://example.com/ext/b"
+        )
+        |> A2A.Plug.call(opts)
+
+      assert conn.status == 200
+      body = json_body(conn)
+      assert body["result"]["task"]["kind"] == "task"
+    end
+  end
+
+  # -- Client extensions -------------------------------------------------------
+
+  describe "client extensions" do
+    test "new/2 stores extensions and sends A2A-Extensions header" do
+      client =
+        A2A.Client.new("http://localhost:4000",
+          extensions: ["https://example.com/ext/a", "https://example.com/ext/b"],
+          plug: {A2A.Plug, plug_opts(self())}
+        )
+
+      assert client.extensions == ["https://example.com/ext/a", "https://example.com/ext/b"]
+
+      # Verify the header is set in the Req request
+      headers = client.req.headers
+      ext_header = Map.get(headers, "a2a-extensions")
+      assert ext_header == ["https://example.com/ext/a, https://example.com/ext/b"]
+    end
+
+    test "new/2 without extensions does not set header" do
+      client = A2A.Client.new("http://localhost:4000")
+      assert client.extensions == []
+
+      headers = client.req.headers
+      assert Map.get(headers, "a2a-extensions") == nil
+    end
+  end
+end


### PR DESCRIPTION
Part of #13 (A2A v1.0 Protocol Support)

## What This PR Does

Adds A2A extension negotiation via HTTP headers, per the v1.0 spec.

### New Module: `A2A.AgentExtension`

Struct representing a protocol extension declaration (from `a2a.proto AgentExtension`):
- `uri` — unique extension identifier (required)
- `description` — human-readable description
- `required` — if true, client must support this extension
- `params` — optional configuration parameters

### Server Side (`A2A.Plug`)

- New `:extensions` init option accepts a list of `%A2A.AgentExtension{}` structs
- Reads `A2A-Extensions` request header (comma-separated extension URIs)
- Validates client declares all server-required extensions
- Returns `ExtensionSupportRequiredError` (-32008) for missing required extensions
- Sets `A2A-Extensions` response header listing all server-supported extension URIs

### Client Side (`A2A.Client`)

- New `:extensions` option on `new/2` sends `A2A-Extensions` header with requests
- New `parse_extensions_header/1` reads server-supported extensions from response

### New Error Codes

- `ExtensionSupportRequiredError` (-32008)
- `VersionNotSupportedError` (-32009)

### Tests

14 new tests covering:
- Extension negotiation happy path (optional + required extensions)
- Missing required extension error
- Multiple required extensions validation
- Response header with all supported URIs
- Client header sending and struct storage
- AgentExtension struct creation and validation

All 401 existing tests continue to pass.

Fixes part of #13