### PR TITLE
feat(json): emit A2A v1.0 wire format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `A2A.Plug` task-level authorization hook for `tasks/get`, `tasks/cancel`, and
   `tasks/list`
+- A2A v1.0 wire format on encode: flat `Part` (no `kind`, with `text` /
+  `data` / `raw` / `url` / `mediaType` / `filename`); `Task`, `Message`, and
+  `Artifact` no longer carry a `kind` field; AgentCard top-level `url` and
+  `protocolVersion` removed (now per-interface under `supportedInterfaces[]`).
+  Decoder accepts both v1.0 and the legacy v0.3 nested-`file` form, so v0.3
+  clients keep working.
+- `Message.reference_task_ids`, `Artifact.extensions`, and
+  `AgentCard.signatures` struct fields for v1.0 data carriage.
+
+### Changed
+
+- `TaskStatus.timestamp` is now serialized with a `Z` suffix (UTC) per the
+  v1.0 schema timestamp regex.
 
 ## [0.2.0] - 2026-03-06
 

--- a/lib/a2a/agent_card.ex
+++ b/lib/a2a/agent_card.ex
@@ -53,7 +53,8 @@ defmodule A2A.AgentCard do
           protocol_version: String.t() | nil,
           supported_interfaces: [supported_interface()],
           security_schemes: %{String.t() => A2A.SecurityScheme.t()},
-          security: [%{String.t() => [String.t()]}]
+          security: [%{String.t() => [String.t()]}],
+          signatures: [map()]
         }
 
   @enforce_keys [:name, :description, :url, :version, :skills]
@@ -72,6 +73,7 @@ defmodule A2A.AgentCard do
     default_output_modes: ["text/plain"],
     supported_interfaces: [],
     security_schemes: %{},
-    security: []
+    security: [],
+    signatures: []
   ]
 end

--- a/lib/a2a/artifact.ex
+++ b/lib/a2a/artifact.ex
@@ -10,6 +10,7 @@ defmodule A2A.Artifact do
           name: String.t() | nil,
           description: String.t() | nil,
           parts: [A2A.Part.t()],
+          extensions: [String.t()],
           metadata: map()
         }
 
@@ -19,6 +20,7 @@ defmodule A2A.Artifact do
     :name,
     :description,
     parts: [],
+    extensions: [],
     metadata: %{}
   ]
 

--- a/lib/a2a/json.ex
+++ b/lib/a2a/json.ex
@@ -1,20 +1,25 @@
 defmodule A2A.JSON do
   @moduledoc """
-  Codec for converting between Elixir structs and the A2A v0.3 camelCase JSON wire format.
+  Codec for converting between Elixir structs and the A2A v1.0 camelCase JSON wire format.
 
   Produces intermediate maps (not JSON strings) suitable for composing with
   JSON-RPC envelopes. Use `Jason.encode!/1` on the result when you need a string.
+
+  Encoding emits the v1.0 flat shape (no `kind` discriminator, flat `Part`
+  with `text`/`data`/`raw`/`url` + `mediaType`/`filename`). Decoding accepts
+  both v1.0 and the legacy v0.3 shape (nested `file: {bytes|uri, mimeType}`
+  and `kind`-tagged parts) so v0.3 clients keep working.
 
   ## Encoding
 
       iex> part = A2A.Part.Text.new("hello")
       iex> {:ok, map} = A2A.JSON.encode(part)
       iex> map
-      %{"kind" => "text", "text" => "hello"}
+      %{"text" => "hello"}
 
   ## Decoding
 
-      iex> {:ok, part} = A2A.JSON.decode(%{"kind" => "text", "text" => "hello"}, :part)
+      iex> {:ok, part} = A2A.JSON.decode(%{"text" => "hello"}, :part)
       iex> part
       %A2A.Part.Text{text: "hello", metadata: %{}}
   """
@@ -94,8 +99,10 @@ defmodule A2A.JSON do
   def encode(%A2A.Task{} = task) do
     {:ok, status} = encode(task.status)
 
+    # contextId is REQUIRED on the wire (v0.3 TCK + protobuf default "") —
+    # emit an empty string when the struct field is nil.
     map =
-      %{"kind" => "task", "id" => task.id, "contextId" => task.context_id, "status" => status}
+      %{"id" => task.id, "contextId" => task.context_id || "", "status" => status}
       |> put_unless_empty("history", encode_list(task.history))
       |> put_unless_empty("artifacts", encode_list(task.artifacts))
       |> put_unless_empty("metadata", task.metadata)
@@ -115,13 +122,13 @@ defmodule A2A.JSON do
   def encode(%A2A.Message{} = msg) do
     map =
       %{
-        "kind" => "message",
         "role" => Map.fetch!(@role_to_string, msg.role),
         "parts" => encode_list(msg.parts)
       }
       |> put_unless_nil("messageId", msg.message_id)
       |> put_unless_nil("taskId", msg.task_id)
       |> put_unless_nil("contextId", msg.context_id)
+      |> put_unless_empty("referenceTaskIds", msg.reference_task_ids)
       |> put_unless_empty("metadata", msg.metadata)
       |> put_unless_empty("extensions", msg.extensions)
 
@@ -134,6 +141,7 @@ defmodule A2A.JSON do
       |> put_unless_nil("artifactId", artifact.artifact_id)
       |> put_unless_nil("name", artifact.name)
       |> put_unless_nil("description", artifact.description)
+      |> put_unless_empty("extensions", artifact.extensions)
       |> put_unless_empty("metadata", artifact.metadata)
 
     {:ok, map}
@@ -141,17 +149,19 @@ defmodule A2A.JSON do
 
   def encode(%A2A.Part.Text{} = part) do
     map =
-      %{"kind" => "text", "text" => part.text}
+      %{"text" => part.text}
       |> put_unless_empty("metadata", part.metadata)
 
     {:ok, map}
   end
 
-  def encode(%A2A.Part.File{} = part) do
-    {:ok, file} = encode(part.file)
-
+  def encode(%A2A.Part.File{file: %A2A.FileContent{} = fc} = part) do
     map =
-      %{"kind" => "file", "file" => file}
+      %{}
+      |> put_unless_nil("filename", fc.name)
+      |> put_unless_nil("mediaType", fc.mime_type)
+      |> put_unless_nil("url", fc.uri)
+      |> put_unless_nil("raw", encode_bytes(fc.bytes))
       |> put_unless_empty("metadata", part.metadata)
 
     {:ok, map}
@@ -159,7 +169,7 @@ defmodule A2A.JSON do
 
   def encode(%A2A.Part.Data{} = part) do
     map =
-      %{"kind" => "data", "data" => part.data}
+      %{"data" => part.data}
       |> put_unless_empty("metadata", part.metadata)
 
     {:ok, map}
@@ -227,21 +237,27 @@ defmodule A2A.JSON do
   @doc """
   Encodes an agent card map with options into the AgentCard JSON format.
 
+  In v1.0 the top-level `url` and `protocolVersion` fields are gone from the
+  wire format — both are per-interface. The `:url` option is still required
+  because it seeds the default `supportedInterfaces` entry; pass
+  `:supported_interfaces` directly to override.
+
   ## Options
 
-  - `:url` — the agent's endpoint URL (required)
+  - `:url` — agent endpoint URL, used as the default `supportedInterfaces[0].url`
   - `:capabilities` — `AgentCapabilities` map (default: `%{}`)
   - `:default_input_modes` — list of MIME types (default: `["text/plain"]`)
   - `:default_output_modes` — list of MIME types (default: `["text/plain"]`)
   - `:provider` — `%{organization: ..., url: ...}` map
   - `:documentation_url` — URL string
   - `:icon_url` — URL string
-  - `:protocol_version` — protocol version string
   - `:supported_interfaces` — list of `%{url: ..., protocol_binding: ...,
     protocol_version: ...}` maps. Defaults to a single JSON-RPC interface
     derived from `:url`.
   - `:security_schemes` — `%{name => %SecurityScheme.X{}}` map
   - `:security` — list of `%{name => scopes}` maps (OpenAPI-style)
+  - `:signatures` — list of JWS signature maps (each `%{"protected" => ...,
+    "signature" => ..., "header" => ...}`)
   """
   @spec encode_agent_card(A2A.Agent.card(), keyword()) :: map()
   def encode_agent_card(card, opts \\ []) do
@@ -273,7 +289,6 @@ defmodule A2A.JSON do
       %{
         "name" => card.name,
         "description" => card.description,
-        "url" => url,
         "version" => card.version,
         "skills" => skills,
         "capabilities" => caps,
@@ -284,9 +299,9 @@ defmodule A2A.JSON do
       |> put_unless_nil("provider", encode_provider(Keyword.get(opts, :provider)))
       |> put_unless_nil("documentationUrl", Keyword.get(opts, :documentation_url))
       |> put_unless_nil("iconUrl", Keyword.get(opts, :icon_url))
-      |> put_unless_nil("protocolVersion", Keyword.get(opts, :protocol_version))
       |> put_unless_empty("securitySchemes", encode_security_schemes(security_schemes))
       |> put_unless_empty("security", security)
+      |> put_unless_empty("signatures", Keyword.get(opts, :signatures, []))
 
     map
   end
@@ -315,10 +330,12 @@ defmodule A2A.JSON do
   def decode_agent_card(map) when is_map(map) do
     with {:ok, name} <- require_field(map, "name"),
          {:ok, description} <- require_field(map, "description"),
-         {:ok, url} <- require_field(map, "url"),
          {:ok, version} <- require_field(map, "version"),
          {:ok, skills_list} <- require_field(map, "skills"),
          {:ok, skills} <- decode_card_skills(skills_list) do
+      interfaces = decode_card_interfaces(Map.get(map, "supportedInterfaces", []))
+      url = Map.get(map, "url") || preferred_interface_url(interfaces)
+
       {:ok,
        %A2A.AgentCard{
          name: name,
@@ -333,12 +350,16 @@ defmodule A2A.JSON do
          documentation_url: Map.get(map, "documentationUrl"),
          icon_url: Map.get(map, "iconUrl"),
          protocol_version: Map.get(map, "protocolVersion"),
-         supported_interfaces: decode_card_interfaces(Map.get(map, "supportedInterfaces", [])),
+         supported_interfaces: interfaces,
          security_schemes: decode_card_security_schemes(Map.get(map, "securitySchemes", %{})),
-         security: Map.get(map, "security", [])
+         security: Map.get(map, "security", []),
+         signatures: Map.get(map, "signatures", [])
        }}
     end
   end
+
+  defp preferred_interface_url([%{url: url} | _]) when is_binary(url), do: url
+  defp preferred_interface_url(_), do: nil
 
   # -------------------------------------------------------------------
   # Decoding
@@ -412,6 +433,7 @@ defmodule A2A.JSON do
          parts: parts,
          task_id: Map.get(map, "taskId"),
          context_id: Map.get(map, "contextId"),
+         reference_task_ids: Map.get(map, "referenceTaskIds", []),
          metadata: Map.get(map, "metadata", %{}),
          extensions: Map.get(map, "extensions", %{})
        }}
@@ -427,6 +449,7 @@ defmodule A2A.JSON do
          name: Map.get(map, "name"),
          description: Map.get(map, "description"),
          parts: parts,
+         extensions: Map.get(map, "extensions", []),
          metadata: Map.get(map, "metadata", %{})
        }}
     end
@@ -518,7 +541,13 @@ defmodule A2A.JSON do
     Map.fetch!(@state_to_string, state)
   end
 
-  defp encode_timestamp(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+  defp encode_timestamp(%DateTime{} = dt) do
+    dt
+    |> DateTime.shift_zone!("Etc/UTC")
+    |> DateTime.to_iso8601(:extended)
+    |> String.replace_suffix("+00:00", "Z")
+  end
+
   defp encode_timestamp(nil), do: nil
 
   defp encode_bytes(nil), do: nil
@@ -683,12 +712,14 @@ defmodule A2A.JSON do
     end
   end
 
-  # v0.3: parts may omit "kind" — infer from content field presence
+  # Parts without "kind": v1.0 is flat ({"text"|"data"|"raw"|"url": ...}),
+  # v0.3 nests file content under {"file": {...}}.
   defp infer_part_type(map) do
     cond do
       Map.has_key?(map, "text") -> decode_text_part(map)
-      Map.has_key?(map, "file") -> decode_file_part(map)
       Map.has_key?(map, "data") -> decode_data_part(map)
+      Map.has_key?(map, "file") -> decode_file_part(map)
+      Map.has_key?(map, "raw") or Map.has_key?(map, "url") -> decode_flat_file_part(map)
       true -> {:error, {:missing_field, "kind"}}
     end
   end
@@ -719,6 +750,23 @@ defmodule A2A.JSON do
       {:ok,
        %A2A.Part.Data{
          data: data,
+         metadata: Map.get(map, "metadata", %{})
+       }}
+    end
+  end
+
+  defp decode_flat_file_part(map) do
+    with {:ok, bytes} <- decode_base64(Map.get(map, "raw")) do
+      file = %A2A.FileContent{
+        name: Map.get(map, "filename"),
+        mime_type: Map.get(map, "mediaType"),
+        bytes: bytes,
+        uri: Map.get(map, "url")
+      }
+
+      {:ok,
+       %A2A.Part.File{
+         file: file,
          metadata: Map.get(map, "metadata", %{})
        }}
     end

--- a/lib/a2a/message.ex
+++ b/lib/a2a/message.ex
@@ -13,6 +13,7 @@ defmodule A2A.Message do
           parts: [A2A.Part.t()],
           task_id: String.t() | nil,
           context_id: String.t() | nil,
+          reference_task_ids: [String.t()],
           metadata: map(),
           extensions: map()
         }
@@ -24,6 +25,7 @@ defmodule A2A.Message do
     :task_id,
     :context_id,
     parts: [],
+    reference_task_ids: [],
     metadata: %{},
     extensions: %{}
   ]

--- a/test/a2a/json_test.exs
+++ b/test/a2a/json_test.exs
@@ -10,9 +10,10 @@ defmodule A2A.JSONTest do
   # -------------------------------------------------------------------
 
   describe "encode Part.Text" do
-    test "produces camelCase map" do
+    test "produces flat v1.0 map" do
       part = Part.Text.new("hello")
-      assert {:ok, %{"kind" => "text", "text" => "hello"}} = JSON.encode(part)
+      assert {:ok, %{"text" => "hello"} = map} = JSON.encode(part)
+      refute Map.has_key?(map, "kind")
     end
 
     test "omits empty metadata" do
@@ -27,7 +28,7 @@ defmodule A2A.JSONTest do
   end
 
   describe "encode Part.File" do
-    test "encodes file with bytes as base64" do
+    test "encodes bytes as flat v1.0 raw + mediaType + filename" do
       fc =
         FileContent.from_bytes("binary data",
           name: "f.bin",
@@ -37,28 +38,30 @@ defmodule A2A.JSONTest do
       part = Part.File.new(fc)
       {:ok, map} = JSON.encode(part)
 
-      assert map["kind"] == "file"
-      assert map["file"]["bytes"] == Base.encode64("binary data")
-      assert map["file"]["name"] == "f.bin"
-      assert map["file"]["mimeType"] == "application/octet-stream"
+      refute Map.has_key?(map, "kind")
+      refute Map.has_key?(map, "file")
+      assert map["raw"] == Base.encode64("binary data")
+      assert map["filename"] == "f.bin"
+      assert map["mediaType"] == "application/octet-stream"
     end
 
-    test "encodes file with URI" do
+    test "encodes URI as flat v1.0 url" do
       fc = FileContent.from_uri("https://example.com/file.pdf")
       part = Part.File.new(fc)
       {:ok, map} = JSON.encode(part)
 
-      assert map["file"]["uri"] == "https://example.com/file.pdf"
-      refute Map.has_key?(map["file"], "bytes")
+      assert map["url"] == "https://example.com/file.pdf"
+      refute Map.has_key?(map, "raw")
+      refute Map.has_key?(map, "file")
     end
   end
 
   describe "encode Part.Data" do
-    test "produces camelCase map" do
+    test "produces flat v1.0 map" do
       part = Part.Data.new(%{key: "val"})
       {:ok, map} = JSON.encode(part)
 
-      assert map["kind"] == "data"
+      refute Map.has_key?(map, "kind")
       assert map["data"] == %{key: "val"}
     end
   end
@@ -84,7 +87,7 @@ defmodule A2A.JSONTest do
   end
 
   describe "encode Message" do
-    test "produces camelCase map with kind" do
+    test "produces flat v1.0 camelCase map" do
       msg = %Message{
         message_id: "msg-1",
         role: :user,
@@ -95,12 +98,12 @@ defmodule A2A.JSONTest do
 
       {:ok, map} = JSON.encode(msg)
 
-      assert map["kind"] == "message"
+      refute Map.has_key?(map, "kind")
       assert map["messageId"] == "msg-1"
       assert map["role"] == "ROLE_USER"
       assert map["taskId"] == "tsk-1"
       assert map["contextId"] == "ctx-1"
-      assert [%{"kind" => "text", "text" => "hello"}] = map["parts"]
+      assert [%{"text" => "hello"}] = map["parts"]
     end
 
     test "omits nil optional fields" do
@@ -110,8 +113,15 @@ defmodule A2A.JSONTest do
       refute Map.has_key?(map, "messageId")
       refute Map.has_key?(map, "taskId")
       refute Map.has_key?(map, "contextId")
+      refute Map.has_key?(map, "referenceTaskIds")
       refute Map.has_key?(map, "metadata")
       refute Map.has_key?(map, "extensions")
+    end
+
+    test "emits referenceTaskIds when non-empty" do
+      msg = %Message{role: :user, parts: [Part.Text.new("x")], reference_task_ids: ["a", "b"]}
+      {:ok, map} = JSON.encode(msg)
+      assert map["referenceTaskIds"] == ["a", "b"]
     end
   end
 
@@ -130,7 +140,7 @@ defmodule A2A.JSONTest do
       assert map["artifactId"] == "art-1"
       assert map["name"] == "result"
       assert map["description"] == "desc"
-      assert [%{"kind" => "text"}] = map["parts"]
+      assert [%{"text" => "output"}] = map["parts"]
       assert map["metadata"] == %{type: "text"}
     end
 
@@ -141,7 +151,18 @@ defmodule A2A.JSONTest do
       refute Map.has_key?(map, "artifactId")
       refute Map.has_key?(map, "name")
       refute Map.has_key?(map, "description")
+      refute Map.has_key?(map, "extensions")
       refute Map.has_key?(map, "metadata")
+    end
+
+    test "emits extensions when non-empty" do
+      artifact = %Artifact{
+        parts: [Part.Text.new("x")],
+        extensions: ["https://example.com/ext"]
+      }
+
+      {:ok, map} = JSON.encode(artifact)
+      assert map["extensions"] == ["https://example.com/ext"]
     end
   end
 
@@ -164,17 +185,18 @@ defmodule A2A.JSONTest do
       assert map["state"] == "TASK_STATE_WORKING"
     end
 
-    test "encodes timestamp as ISO8601" do
+    test "encodes timestamp as ISO 8601 with Z suffix" do
       status = Task.Status.new(:submitted)
       {:ok, map} = JSON.encode(status)
       assert {:ok, _, _} = DateTime.from_iso8601(map["timestamp"])
+      assert map["timestamp"] =~ ~r/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/
     end
 
     test "encodes nested message" do
       msg = Message.new_agent("status info")
       status = Task.Status.new(:working, msg)
       {:ok, map} = JSON.encode(status)
-      assert map["message"]["kind"] == "message"
+      refute Map.has_key?(map["message"], "kind")
       assert map["message"]["role"] == "ROLE_AGENT"
     end
 
@@ -186,11 +208,11 @@ defmodule A2A.JSONTest do
   end
 
   describe "encode Task" do
-    test "produces full camelCase map with kind" do
+    test "produces flat v1.0 camelCase map" do
       task = Task.new(context_id: "ctx-1")
       {:ok, map} = JSON.encode(task)
 
-      assert map["kind"] == "task"
+      refute Map.has_key?(map, "kind")
       assert is_binary(map["id"])
       assert map["contextId"] == "ctx-1"
       assert map["status"]["state"] == "TASK_STATE_SUBMITTED"
@@ -202,6 +224,8 @@ defmodule A2A.JSONTest do
 
       refute Map.has_key?(map, "history")
       refute Map.has_key?(map, "artifacts")
+      # contextId is always emitted (defaults to "" when nil) — TCK requires it.
+      assert map["contextId"] == ""
     end
 
     test "includes non-empty history" do
@@ -209,7 +233,9 @@ defmodule A2A.JSONTest do
       task = Task.new(history: [msg])
       {:ok, map} = JSON.encode(task)
 
-      assert [%{"kind" => "message"}] = map["history"]
+      assert [m] = map["history"]
+      assert m["role"] == "ROLE_USER"
+      refute Map.has_key?(m, "kind")
     end
   end
 
@@ -706,6 +732,137 @@ defmodule A2A.JSONTest do
   end
 
   # -------------------------------------------------------------------
+  # v1.0 wire-format guards (mirror A2A v1.0 TCK DM-* assertions)
+  # -------------------------------------------------------------------
+
+  describe "v1.0 wire format" do
+    # Mirror of .tck-v1/tests/compatibility/core_operations/test_data_model.py
+    # _SNAKE_CASE_PATTERN — DM-SERIAL-001.
+    @snake_case ~r/^[a-z]+(_[a-z]+)+$/
+
+    defp collect_keys(map, acc) when is_map(map) do
+      map
+      |> Map.keys()
+      |> Enum.into(acc)
+      |> then(fn acc ->
+        Enum.reduce(map, acc, fn {_, v}, a -> collect_keys(v, a) end)
+      end)
+    end
+
+    defp collect_keys(list, acc) when is_list(list),
+      do: Enum.reduce(list, acc, &collect_keys/2)
+
+    defp collect_keys(_other, acc), do: acc
+
+    defp assert_no_snake_case(map) do
+      offending = map |> collect_keys(MapSet.new()) |> Enum.filter(&(&1 =~ @snake_case))
+      assert offending == [], "snake_case keys present: #{inspect(offending)}"
+    end
+
+    defp collect_values(map, key, acc) when is_map(map) do
+      acc = if Map.has_key?(map, key), do: [Map.get(map, key) | acc], else: acc
+      Enum.reduce(map, acc, fn {_, v}, a -> collect_values(v, key, a) end)
+    end
+
+    defp collect_values(list, key, acc) when is_list(list),
+      do: Enum.reduce(list, acc, fn item, a -> collect_values(item, key, a) end)
+
+    defp collect_values(_other, _key, acc), do: acc
+
+    test "Task / Message / Artifact have no snake_case keys" do
+      task = %Task{
+        id: "tsk-1",
+        context_id: "ctx-1",
+        status: Task.Status.new(:working),
+        history: [
+          %Message{
+            message_id: "m1",
+            role: :user,
+            parts: [Part.Text.new("hi")],
+            task_id: "tsk-1",
+            context_id: "ctx-1",
+            reference_task_ids: ["other"]
+          }
+        ],
+        artifacts: [%Artifact{artifact_id: "a1", parts: [Part.Text.new("x")]}]
+      }
+
+      assert_no_snake_case(JSON.encode!(task))
+    end
+
+    test "AgentCard has no snake_case keys" do
+      card = %{name: "n", description: "d", version: "1", skills: [], opts: []}
+      assert_no_snake_case(JSON.encode_agent_card(card, url: "https://example.com"))
+    end
+
+    test "enum values (state, role) serialize as strings" do
+      task = %Task{
+        id: "t",
+        status: Task.Status.new(:working, Message.new_agent("ok")),
+        history: [Message.new_user("hi")]
+      }
+
+      map = JSON.encode!(task)
+
+      for state <- collect_values(map, "state", []) do
+        assert is_binary(state), "state must be string, got #{inspect(state)}"
+      end
+
+      for role <- collect_values(map, "role", []) do
+        assert is_binary(role), "role must be string, got #{inspect(role)}"
+      end
+    end
+
+    test "TaskStatus timestamp matches ISO 8601 + Z (DM-SERIAL-003)" do
+      iso_z = ~r/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/
+
+      json_str =
+        Task.Status.new(:working)
+        |> JSON.encode!()
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      assert json_str["timestamp"] =~ iso_z
+    end
+
+    test "flat v1.0 file part decodes (raw / mediaType / filename)" do
+      map = %{
+        "raw" => Base.encode64("hello"),
+        "mediaType" => "text/plain",
+        "filename" => "greet.txt"
+      }
+
+      assert {:ok, %Part.File{file: %FileContent{} = fc}} = JSON.decode(map, :part)
+      assert fc.bytes == "hello"
+      assert fc.mime_type == "text/plain"
+      assert fc.name == "greet.txt"
+    end
+
+    test "flat v1.0 file part with url decodes" do
+      map = %{"url" => "https://example.com/f.pdf", "mediaType" => "application/pdf"}
+
+      assert {:ok, %Part.File{file: %FileContent{uri: "https://example.com/f.pdf"}}} =
+               JSON.decode(map, :part)
+    end
+
+    test "legacy v0.3 nested file part still decodes (backwards-compat)" do
+      legacy = %{
+        "kind" => "file",
+        "file" => %{
+          "bytes" => Base.encode64("hi"),
+          "mimeType" => "text/plain",
+          "name" => "f.txt"
+        }
+      }
+
+      assert {:ok, %Part.File{file: %FileContent{} = fc}} = JSON.decode(legacy, :part)
+      assert fc.bytes == "hi"
+      assert fc.mime_type == "text/plain"
+      assert fc.name == "f.txt"
+    end
+  end
+
+  # -------------------------------------------------------------------
   # Round-trips
   # -------------------------------------------------------------------
 
@@ -849,7 +1006,8 @@ defmodule A2A.JSONTest do
   describe "encode!/1" do
     test "returns map on success" do
       map = JSON.encode!(Part.Text.new("hi"))
-      assert %{"kind" => "text", "text" => "hi"} = map
+      assert %{"text" => "hi"} = map
+      refute Map.has_key?(map, "kind")
     end
 
     test "raises on error" do
@@ -861,7 +1019,7 @@ defmodule A2A.JSONTest do
 
   describe "decode!/2" do
     test "returns struct on success" do
-      part = JSON.decode!(%{"kind" => "text", "text" => "hi"}, :part)
+      part = JSON.decode!(%{"text" => "hi"}, :part)
       assert %Part.Text{text: "hi"} = part
     end
 
@@ -892,7 +1050,7 @@ defmodule A2A.JSONTest do
 
       assert map["name"] == "test-agent"
       assert map["description"] == "A test agent"
-      assert map["url"] == "https://example.com/a2a"
+      refute Map.has_key?(map, "url")
       assert map["version"] == "1.0.0"
       assert [%{"id" => "greet", "tags" => ["greeting"]}] = map["skills"]
       assert map["capabilities"] == %{}
@@ -955,7 +1113,7 @@ defmodule A2A.JSONTest do
           provider: %{organization: "Acme", url: "https://acme.example.com"},
           documentation_url: "https://docs.example.com",
           icon_url: "https://example.com/icon.png",
-          protocol_version: "0.3"
+          signatures: [%{"protected" => "p", "signature" => "s"}]
         )
 
       assert map["capabilities"] == %{"streaming" => true, "pushNotifications" => false}
@@ -963,7 +1121,9 @@ defmodule A2A.JSONTest do
       assert map["provider"] == %{"organization" => "Acme", "url" => "https://acme.example.com"}
       assert map["documentationUrl"] == "https://docs.example.com"
       assert map["iconUrl"] == "https://example.com/icon.png"
-      assert map["protocolVersion"] == "0.3"
+      assert map["signatures"] == [%{"protected" => "p", "signature" => "s"}]
+      refute Map.has_key?(map, "url")
+      refute Map.has_key?(map, "protocolVersion")
       assert [%{"url" => "https://example.com/a2a"}] = map["supportedInterfaces"]
     end
 
@@ -1103,14 +1263,14 @@ defmodule A2A.JSONTest do
           capabilities: %{streaming: true},
           provider: %{organization: "Org", url: "https://org.example.com"},
           documentation_url: "https://docs.example.com",
-          icon_url: "https://icon.example.com",
-          protocol_version: "0.3"
+          icon_url: "https://icon.example.com"
         )
 
       {:ok, decoded} = JSON.decode_agent_card(encoded)
 
       assert decoded.name == "roundtrip"
       assert decoded.description == "Roundtrip test"
+      # v1.0 wire has no top-level url; URL comes from the preferred interface.
       assert decoded.url == "https://example.com"
       assert decoded.version == "1.0.0"
       assert [%{id: "s1", name: "Skill One", tags: ["tag1"]}] = decoded.skills
@@ -1122,7 +1282,6 @@ defmodule A2A.JSONTest do
       assert decoded.provider == %{organization: "Org", url: "https://org.example.com"}
       assert decoded.documentation_url == "https://docs.example.com"
       assert decoded.icon_url == "https://icon.example.com"
-      assert decoded.protocol_version == "0.3"
     end
   end
 

--- a/test/a2a/jsonrpc_test.exs
+++ b/test/a2a/jsonrpc_test.exs
@@ -28,9 +28,11 @@ defmodule A2A.JSONRPCTest do
       assert response["jsonrpc"] == "2.0"
       assert response["id"] == 1
       assert %{"task" => task} = response["result"]
-      assert task["kind"] == "task"
+      refute Map.has_key?(task, "kind")
       assert task["status"]["state"] == "TASK_STATE_COMPLETED"
-      assert [%{"kind" => "message"}] = task["history"]
+      assert [msg] = task["history"]
+      refute Map.has_key?(msg, "kind")
+      assert msg["role"] == "ROLE_USER"
     end
 
     test "bad message returns invalid_params" do
@@ -159,7 +161,9 @@ defmodule A2A.JSONRPCTest do
       {:reply, response} =
         JSONRPC.handle(rpc("SendMessage", message_params()), @handler)
 
-      assert response["result"]["task"]["kind"] == "task"
+      task = response["result"]["task"]
+      assert is_binary(task["id"])
+      assert task["status"]["state"] == "TASK_STATE_COMPLETED"
     end
 
     test "SendStreamingMessage dispatches as message/stream" do

--- a/test/a2a/plug/sse_test.exs
+++ b/test/a2a/plug/sse_test.exs
@@ -64,7 +64,9 @@ defmodule A2A.Plug.SSETest do
 
       assert first["jsonrpc"] == "2.0"
       assert first["id"] == 1
-      assert first["result"]["kind"] == "task"
+      assert is_binary(first["result"]["id"])
+      assert first["result"]["status"]["state"]
+      refute Map.has_key?(first["result"], "kind")
     end
 
     test "middle events are artifact updates", %{agent: agent} do

--- a/test/a2a/plug_test.exs
+++ b/test/a2a/plug_test.exs
@@ -58,7 +58,11 @@ defmodule A2A.PlugTest do
 
       body = json_body(conn)
       assert body["name"] == "echo"
-      assert body["url"] == "http://localhost:4000"
+      refute Map.has_key?(body, "url")
+
+      assert [%{"url" => "http://localhost:4000"} | _] =
+               body["supportedInterfaces"]
+
       assert is_list(body["skills"])
     end
 
@@ -111,7 +115,7 @@ defmodule A2A.PlugTest do
         |> A2A.Plug.call(opts)
 
       assert conn.status == 200
-      assert json_body(conn)["result"]["task"]["kind"] == "task"
+      assert is_binary(json_body(conn)["result"]["task"]["id"])
     end
   end
 
@@ -128,7 +132,7 @@ defmodule A2A.PlugTest do
       body = json_body(conn)
       assert body["jsonrpc"] == "2.0"
       assert body["id"] == 1
-      assert body["result"]["task"]["kind"] == "task"
+      assert is_binary(body["result"]["task"]["id"])
       assert body["result"]["task"]["status"]["state"] == "TASK_STATE_COMPLETED"
     end
 
@@ -147,7 +151,7 @@ defmodule A2A.PlugTest do
         |> A2A.Plug.call(plug_opts(agent))
 
       body = json_body(conn)
-      assert body["result"]["task"]["kind"] == "task"
+      assert is_binary(body["result"]["task"]["id"])
       assert body["result"]["task"]["status"]["state"] == "TASK_STATE_COMPLETED"
     end
 
@@ -387,7 +391,10 @@ defmodule A2A.PlugTest do
         |> A2A.Plug.call(plug_opts(agent))
 
       assert conn.status == 200
-      assert json_body(conn)["url"] == "https://tenant.example.com/a2a"
+      refute Map.has_key?(json_body(conn), "url")
+
+      assert [%{"url" => "https://tenant.example.com/a2a"} | _] =
+               json_body(conn)["supportedInterfaces"]
     end
 
     test "get_base_url/1 returns stored value" do
@@ -503,7 +510,7 @@ defmodule A2A.PlugTest do
         |> A2A.Plug.call(opts)
 
       assert conn.status == 200
-      assert json_body(conn)["result"]["task"]["kind"] == "task"
+      assert is_binary(json_body(conn)["result"]["task"]["id"])
     end
   end
 
@@ -527,7 +534,7 @@ defmodule A2A.PlugTest do
         |> A2A.Plug.call(opts)
 
       assert conn.status == 200
-      assert json_body(conn)["result"]["task"]["kind"] == "task"
+      assert is_binary(json_body(conn)["result"]["task"]["id"])
     end
   end
 

--- a/test/a2a_test.exs
+++ b/test/a2a_test.exs
@@ -95,7 +95,8 @@ defmodule A2ATest do
       card = A2A.get_agent_card(pid, base_url: "https://example.com/a2a")
 
       assert card["name"] == "echo"
-      assert card["url"] == "https://example.com/a2a"
+      refute Map.has_key?(card, "url")
+      assert [%{"url" => "https://example.com/a2a"} | _] = card["supportedInterfaces"]
       assert is_list(card["skills"])
     end
 


### PR DESCRIPTION
## Summary

First PR in the v1.0 series (#13): encoder emits the flat v1.0 wire shape. Decoder accepts both v1.0 and the legacy v0.3 nested-`file` form, so v0.3 clients keep working.

## Changes

- Drop `kind` discriminator from `Task`, `Message`, and all `Part` variants.
- Flatten `Part.File` to `raw`/`url` + `mediaType` + `filename` (no nested `file` object).
- Remove top-level `url` and `protocolVersion` from `AgentCard` (now per-interface).
- Render `TaskStatus.timestamp` with `Z` suffix; always emit `contextId` on `Task`.
- Add struct fields: `Message.reference_task_ids`, `Artifact.extensions`, `AgentCard.signatures`.

## Verification

- v0.3 TCK (`bin/tck mandatory`): 83 passed, 0 failed — no regression.
- v1.0 TCK data-model + agent-card structure: 10/10 pass.
- `mix test` (400 tests), `mix quality` clean.

## Type of change

- [x] New feature
- [x] Breaking change (wire format on the encoder side)

Refs #13.