### PR TITLE
feat(client): send v1.0 PascalCase JSON-RPC methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `TaskStatus.timestamp` is now serialized with a `Z` suffix (UTC) per the
   v1.0 schema timestamp regex.
+- `A2A.Client` now sends v1.0 PascalCase JSON-RPC method names
+  (`SendMessage`, `SendStreamingMessage`, `GetTask`, `CancelTask`). The
+  server continues to accept both v1.0 PascalCase and the legacy v0.3
+  slash-style names. Pointing the client at a strict v0.3-only server that
+  doesn't accept PascalCase is a breaking change.
 
 ## [0.2.0] - 2026-03-06
 

--- a/lib/a2a/client.ex
+++ b/lib/a2a/client.ex
@@ -128,7 +128,7 @@ if Code.ensure_loaded?(Req) do
     end
 
     @doc """
-    Sends a message to an agent via `message/send`.
+    Sends a message to an agent via `SendMessage`.
 
     Returns `{:ok, task}` on success or `{:error, reason}` on failure.
     The message can be a string, an `%A2A.Message{}`, or a list of parts.
@@ -152,7 +152,7 @@ if Code.ensure_loaded?(Req) do
     def send_message(target, message, opts \\ []) do
       client = ensure_client(target)
       {params, req_opts} = build_send_params(message, opts)
-      body = jsonrpc_request("message/send", params)
+      body = jsonrpc_request("SendMessage", params)
 
       case post(client, body, req_opts) do
         {:ok, response} -> decode_jsonrpc_result(response, :task)
@@ -163,7 +163,7 @@ if Code.ensure_loaded?(Req) do
     @doc """
     Sends a message and returns a stream of decoded SSE events.
 
-    Uses `message/stream` to receive server-sent events. Returns
+    Uses `SendStreamingMessage` to receive server-sent events. Returns
     `{:ok, stream}` where the stream yields decoded structs
     (`%A2A.Task{}`, `%A2A.Event.StatusUpdate{}`, `%A2A.Event.ArtifactUpdate{}`,
     or `%A2A.Message{}`).
@@ -185,7 +185,7 @@ if Code.ensure_loaded?(Req) do
     def stream_message(target, message, opts \\ []) do
       client = ensure_client(target)
       {params, req_opts} = build_send_params(message, opts)
-      body = jsonrpc_request("message/stream", params)
+      body = jsonrpc_request("SendStreamingMessage", params)
 
       json_body = Jason.encode!(body)
       req = merge_req_opts(client.req, req_opts)
@@ -208,7 +208,7 @@ if Code.ensure_loaded?(Req) do
     end
 
     @doc """
-    Retrieves a task by ID via `tasks/get`.
+    Retrieves a task by ID via `GetTask`.
 
     ## Options
 
@@ -230,7 +230,7 @@ if Code.ensure_loaded?(Req) do
         %{"id" => task_id}
         |> put_opt("historyLength", opts[:history_length])
 
-      body = jsonrpc_request("tasks/get", params)
+      body = jsonrpc_request("GetTask", params)
 
       case post(client, body, req_opts) do
         {:ok, response} -> decode_jsonrpc_result(response, :task)
@@ -239,7 +239,7 @@ if Code.ensure_loaded?(Req) do
     end
 
     @doc """
-    Cancels a task by ID via `tasks/cancel`.
+    Cancels a task by ID via `CancelTask`.
 
     ## Options
 
@@ -256,7 +256,7 @@ if Code.ensure_loaded?(Req) do
       client = ensure_client(target)
       req_opts = take_req_opts(opts)
       params = %{"id" => task_id}
-      body = jsonrpc_request("tasks/cancel", params)
+      body = jsonrpc_request("CancelTask", params)
 
       case post(client, body, req_opts) do
         {:ok, response} -> decode_jsonrpc_result(response, :task)

--- a/test/a2a/client_test.exs
+++ b/test/a2a/client_test.exs
@@ -103,7 +103,7 @@ defmodule A2A.ClientTest do
       plug = fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         decoded = Jason.decode!(body)
-        assert decoded["method"] == "message/send"
+        assert decoded["method"] == "SendMessage"
         assert decoded["params"]["message"]["role"] == "ROLE_USER"
 
         json_resp(conn, 200, jsonrpc_success(%{"task" => @task_json}))
@@ -211,7 +211,7 @@ defmodule A2A.ClientTest do
       plug = fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         decoded = Jason.decode!(body)
-        assert decoded["method"] == "tasks/get"
+        assert decoded["method"] == "GetTask"
         assert decoded["params"]["id"] == "tsk-123"
 
         json_resp(conn, 200, jsonrpc_success(@task_json))
@@ -244,7 +244,7 @@ defmodule A2A.ClientTest do
       plug = fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         decoded = Jason.decode!(body)
-        assert decoded["method"] == "tasks/cancel"
+        assert decoded["method"] == "CancelTask"
         assert decoded["params"]["id"] == "tsk-123"
 
         json_resp(conn, 200, jsonrpc_success(canceled_json))
@@ -338,6 +338,31 @@ defmodule A2A.ClientTest do
           {:ok, conn} = Plug.Conn.chunk(conn, data)
           conn
       end
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # End-to-end (Client + Plug)
+  # -------------------------------------------------------------------
+
+  describe "Client <-> Plug round-trip" do
+    test "send_message reaches the in-process server using v1.0 method names" do
+      agent = start_supervised!({A2A.Test.EchoAgent, name: nil})
+
+      plug_opts = A2A.Plug.init(agent: agent, base_url: "http://localhost")
+
+      plug = fn conn ->
+        # Force the test conn through the body parser so it looks like a real
+        # POST. Plug.Test conns ship the body in :params already.
+        conn
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> A2A.Plug.call(plug_opts)
+      end
+
+      client = Client.new("http://localhost", plug: plug)
+
+      assert {:ok, %A2A.Task{} = task} = Client.send_message(client, "hello")
+      assert task.status.state == :completed
     end
   end
 


### PR DESCRIPTION
## Summary

PR 2 of the v1.0 series (#13). `A2A.Client` now sends v1.0 PascalCase method names; server already accepts both forms.

## Changes

- `send_message` → `SendMessage`
- `stream_message` → `SendStreamingMessage`
- `get_task` → `GetTask`
- `cancel_task` → `CancelTask`
- New end-to-end test: Client + in-process Plug round-trip on v1.0 wire.

## Verification

- `mix test` (401 tests), `mix quality` clean.
- v1.0 TCK data-model + agent-card: still 10/10 (server unchanged).
- Note: `bin/tck` is broken upstream (TCK CLI changed `--sut-url` → `--sut-host`); needs a separate script fix.

## Type of change

- [x] New feature
- [x] Breaking change (clients pointed at strict v0.3-only servers that don't accept PascalCase will break)

Refs #13. Stacked on top of #36 (already merged).