### PR TITLE
feat(jsonrpc): add v1.0 extension and version error types

### DIFF
--- a/lib/a2a/jsonrpc/error.ex
+++ b/lib/a2a/jsonrpc/error.ex
@@ -2,8 +2,8 @@ defmodule A2A.JSONRPC.Error do
   @moduledoc """
   JSON-RPC 2.0 error with A2A-specific error codes.
 
-  Provides a struct and named constructors for the 12 error codes defined by
-  the A2A protocol (5 standard JSON-RPC + 7 A2A-specific).
+  Provides a struct and named constructors for the 14 error codes defined by
+  the A2A protocol (5 standard JSON-RPC + 9 A2A-specific).
 
   ## Example
 
@@ -115,6 +115,26 @@ defmodule A2A.JSONRPC.Error do
     %__MODULE__{
       code: -32_007,
       message: "Authenticated Extended Card is not configured",
+      data: data
+    }
+  end
+
+  @doc "Builds an extension support required error (-32008)."
+  @spec extension_support_required(term()) :: t()
+  def extension_support_required(data \\ nil) do
+    %__MODULE__{
+      code: -32_008,
+      message: "Extension support is required",
+      data: data
+    }
+  end
+
+  @doc "Builds a version not supported error (-32009)."
+  @spec version_not_supported(term()) :: t()
+  def version_not_supported(data \\ nil) do
+    %__MODULE__{
+      code: -32_009,
+      message: "Version not supported",
       data: data
     }
   end

--- a/test/a2a/jsonrpc/error_test.exs
+++ b/test/a2a/jsonrpc/error_test.exs
@@ -79,6 +79,20 @@ defmodule A2A.JSONRPC.ErrorTest do
       assert e.message == "Authenticated Extended Card is not configured"
     end
 
+    test "extension_support_required/0" do
+      e = Error.extension_support_required()
+      assert e.code == -32_008
+      assert e.message == "Extension support is required"
+      assert e.data == nil
+    end
+
+    test "version_not_supported/0" do
+      e = Error.version_not_supported()
+      assert e.code == -32_009
+      assert e.message == "Version not supported"
+      assert e.data == nil
+    end
+
     test "constructors accept optional data" do
       e = Error.parse_error("unexpected token")
       assert e.data == "unexpected token"


### PR DESCRIPTION
## Summary

PR 3 of the v1.0 series (#13). Adds the two new JSON-RPC error constructors v1.0 introduces — `ExtensionSupportRequiredError` (-32008) and `VersionNotSupportedError` (-32009) — so the upcoming extension-negotiation and `A2A-Version` header PRs can use them without bundling unrelated changes.

## Changes

- `A2A.JSONRPC.Error.extension_support_required/1` → -32008 / "Extension support is required"
- `A2A.JSONRPC.Error.version_not_supported/1` → -32009 / "Version not supported"
- Bump moduledoc count to 14 errors (5 standard + 9 A2A-specific)

## Verification

- `mix test` (405 tests), `mix quality` clean
- Codes/messages match the original work on `zeroasterisk/a2a-elixir` `feat/v1-error-types`

## Type of change

- [x] New feature

Refs #13.