### PR TITLE
feat(extension): add A2A v1.0 extension mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clients keep working.
 - `Message.reference_task_ids`, `Artifact.extensions`, and
   `AgentCard.signatures` struct fields for v1.0 data carriage.
+- A2A v1.0 extension mechanism: `A2A.Extension` behaviour with
+  `declaration/1`, `activate/3`, `handle_request/3`, and
+  `handle_response/3` callbacks; `A2A.AgentExtension` struct for
+  declarations; `A2A-Extensions` header negotiation in `A2A.Plug` and
+  `A2A.Client`; merge of declared extensions into the agent card's
+  `capabilities.extensions`; `context.extensions` map for agents to read
+  per-request activations; `A2A.Extension.Timestamp` as a reference
+  implementation.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A2A gives you behaviour-based agents that run as GenServer processes. Define an 
 - **Agent registry** — `A2A.Registry` for skill-based agent discovery
 - **Supervision** — `A2A.AgentSupervisor` starts a fleet of agents with one call
 - **Pluggable storage** — `A2A.TaskStore` behaviour with built-in ETS implementation
+- **Protocol extensions** — A2A v1.0 `A2A-Extensions` header negotiation; ship your own `A2A.Extension` modules or use the bundled `A2A.Extension.Timestamp`
 - **Telemetry** — `:telemetry` spans and events for calls, messages, cancels, and state transitions
 
 ## Quick Start
@@ -177,6 +178,7 @@ The [`examples/`](https://github.com/actioncard/a2a-elixir/tree/main/examples) d
 - **[`demo.exs`](https://github.com/actioncard/a2a-elixir/blob/main/examples/demo.exs)** — local agents: simple call, multi-turn, and streaming
 - **[`client_server.exs`](https://github.com/actioncard/a2a-elixir/blob/main/examples/client_server.exs)** — full HTTP client/server with Bandit and `A2A.Client`
 - **[`supervisor_demo.exs`](https://github.com/actioncard/a2a-elixir/blob/main/examples/supervisor_demo.exs)** — `A2A.AgentSupervisor`, registry, and skill-based routing
+- **[`extensions.exs`](https://github.com/actioncard/a2a-elixir/blob/main/examples/extensions.exs)** — `A2A-Extensions` header negotiation end-to-end using `A2A.Extension.Timestamp`
 
 Run any example with:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -316,14 +316,11 @@ forward compatibility with newer spec versions:
 
 ### Extension Metadata Handling
 
-The A2A spec supports extension metadata via HTTP headers and nested metadata
-fields. Not yet implemented. Would require:
-
-- Parsing `a2a-extensions` / `x-a2a-extensions` HTTP headers
-- `A2A.Extension` module with helpers for getting/putting extension metadata
-  on requests and responses
-- `missing_required/2` to check whether required extensions declared by an
-  agent are present in a request
+Implemented. See `A2A.Extension` for the behaviour, `A2A.Plug` and
+`A2A.Client` for `A2A-Extensions` header negotiation, and
+`A2A.Extension.Timestamp` for a reference profile-extension. Method
+extensions (registering new RPC methods) and state-machine extensions
+remain deferred until a concrete user emerges.
 
 ---
 

--- a/examples/extensions.exs
+++ b/examples/extensions.exs
@@ -1,0 +1,112 @@
+# Run with: mix run examples/extensions.exs
+#
+# Demonstrates the A2A v1.0 extension mechanism end-to-end:
+#   - Server declares A2A.Extension.Timestamp in its agent card
+#   - Client advertises support via the A2A-Extensions header
+#   - Server activates the extension, runs handle_request/handle_response
+#   - Round-tripped Task carries timestamp metadata under the extension URI
+
+# ─── Agent ──────────────────────────────────────────────────────────
+
+defmodule Example.EchoAgent do
+  use A2A.Agent,
+    name: "echo-with-extensions",
+    description: "Echo agent that participates in extension negotiation",
+    skills: [
+      %{id: "echo", name: "Echo", description: "Echoes input", tags: ["demo"]}
+    ]
+
+  @impl A2A.Agent
+  def handle_message(message, context) do
+    activated = Map.keys(context.extensions)
+
+    text =
+      "You said: #{A2A.Message.text(message)}. " <>
+        "Activated extensions: #{Enum.join(activated, ", ")}"
+
+    {:reply, [A2A.Part.Text.new(text)]}
+  end
+end
+
+# ─── Server ─────────────────────────────────────────────────────────
+
+IO.puts("=== A2A Extensions Demo ===\n")
+
+{:ok, _agent_pid} = Example.EchoAgent.start_link()
+
+{:ok, server} =
+  Bandit.start_link(
+    plug:
+      {A2A.Plug,
+       agent: Example.EchoAgent,
+       base_url: "http://localhost:4011",
+       extensions: [A2A.Extension.Timestamp]},
+    port: 4011,
+    startup_log: false
+  )
+
+Process.sleep(100)
+IO.puts("Server running on port 4011 with A2A.Extension.Timestamp configured.\n")
+
+# ─── Agent card advertises the extension ───────────────────────────
+
+IO.puts("--- 1. Agent card ---")
+{:ok, card} = A2A.Client.discover("http://localhost:4011")
+
+for ext <- card.capabilities[:extensions] || [] do
+  required = if ext.required, do: "required", else: "optional"
+  IO.puts("  #{ext.uri}  (#{required})")
+  IO.puts("    #{ext.description}")
+end
+
+IO.puts("")
+
+# ─── Round-trip with the client opting in ──────────────────────────
+
+IO.puts("--- 2. Round-trip with client opting in ---")
+
+client =
+  A2A.Client.new("http://localhost:4011",
+    extensions: [A2A.Extension.Timestamp]
+  )
+
+{:ok, task} = A2A.Client.send_message(client, "hello!")
+
+reply =
+  task.history
+  |> Enum.filter(&(&1.role == :agent))
+  |> List.last()
+  |> A2A.Message.text()
+
+IO.puts("  Agent reply: #{reply}")
+
+stamp = task.metadata[A2A.Extension.Timestamp.uri()]
+IO.puts("  Task metadata under extension URI:")
+IO.puts("    received_at:  #{stamp["received_at"]}")
+IO.puts("    completed_at: #{stamp["completed_at"]}")
+IO.puts("    elapsed_ms:   #{stamp["completed_at"] - stamp["received_at"]}")
+IO.puts("")
+
+# ─── Round-trip with the client *not* opting in ────────────────────
+
+IO.puts("--- 3. Round-trip with client not opting in ---")
+
+bare_client = A2A.Client.new("http://localhost:4011")
+{:ok, bare_task} = A2A.Client.send_message(bare_client, "ignore me")
+
+IO.puts("  Agent reply: ")
+
+bare_task.history
+|> Enum.filter(&(&1.role == :agent))
+|> List.last()
+|> A2A.Message.text()
+|> IO.puts()
+
+IO.puts("  Extension URI in task.metadata? #{Map.has_key?(bare_task.metadata, A2A.Extension.Timestamp.uri())}")
+IO.puts("  (Extension was advertised by server but not requested by client.)")
+IO.puts("")
+
+# ─── Cleanup ───────────────────────────────────────────────────────
+
+Supervisor.stop(server)
+IO.puts("Done!")

--- a/lib/a2a/agent.ex
+++ b/lib/a2a/agent.ex
@@ -154,7 +154,8 @@ defmodule A2A.Agent do
           task_id: String.t(),
           context_id: String.t() | nil,
           history: [A2A.Message.t()],
-          metadata: map()
+          metadata: map(),
+          extensions: %{optional(String.t()) => A2A.Extension.activation()}
         }
 
   @type reply ::
@@ -270,12 +271,13 @@ defmodule A2A.Agent do
         task_id = Keyword.get(opts, :task_id)
         context_id = Keyword.get(opts, :context_id)
         metadata = Keyword.get(opts, :metadata, %{})
+        extensions = Keyword.get(opts, :extensions, %{})
 
         result =
           if task_id do
             case A2A.Agent.State.get_task(state, task_id) do
               {:ok, task} ->
-                A2A.Agent.Runtime.continue_task(__MODULE__, message, task, state)
+                A2A.Agent.Runtime.continue_task(__MODULE__, message, task, state, extensions)
 
               {:error, :not_found} ->
                 {:error, :not_found}
@@ -287,7 +289,8 @@ defmodule A2A.Agent do
                message,
                context_id,
                state,
-               metadata
+               metadata,
+               extensions
              )}
           end
 
@@ -312,7 +315,8 @@ defmodule A2A.Agent do
                 task_id: task.id,
                 context_id: task.context_id,
                 history: task.history,
-                metadata: task.metadata
+                metadata: task.metadata,
+                extensions: %{}
               }
 
               span_meta = %{

--- a/lib/a2a/agent/runtime.ex
+++ b/lib/a2a/agent/runtime.ex
@@ -17,12 +17,18 @@ defmodule A2A.Agent.Runtime do
 
   Creates a new task, transitions through states, and calls `handle_message/2`.
   """
-  @spec process_message(module(), Message.t(), String.t() | nil, State.t(), map()) ::
-          {Task.t(), State.t()}
-  def process_message(module, message, context_id, state, metadata \\ %{}) do
+  @spec process_message(
+          module(),
+          Message.t(),
+          String.t() | nil,
+          State.t(),
+          map(),
+          map()
+        ) :: {Task.t(), State.t()}
+  def process_message(module, message, context_id, state, metadata \\ %{}, extensions \\ %{}) do
     task = Task.new(context_id: context_id, metadata: metadata)
     task = %{task | history: [message]}
-    run_task(module, message, task, state)
+    run_task(module, message, task, state, extensions)
   end
 
   @doc """
@@ -31,15 +37,15 @@ defmodule A2A.Agent.Runtime do
   Appends the message to the task's history and re-runs `handle_message/2`.
   Valid for any non-terminal task state.
   """
-  @spec continue_task(module(), Message.t(), Task.t(), State.t()) ::
+  @spec continue_task(module(), Message.t(), Task.t(), State.t(), map()) ::
           {:ok, {Task.t(), State.t()}} | {:error, :not_continuable}
-  def continue_task(module, message, task, state) do
+  def continue_task(module, message, task, state, extensions \\ %{}) do
     if Task.terminal?(task) do
       {:error, :not_continuable}
     else
       task = %{task | history: task.history ++ [message]}
       task = %{task | metadata: Map.delete(task.metadata, :stream)}
-      {:ok, run_task(module, message, task, state)}
+      {:ok, run_task(module, message, task, state, extensions)}
     end
   end
 
@@ -60,14 +66,15 @@ defmodule A2A.Agent.Runtime do
     )
   end
 
-  defp run_task(module, message, task, state) do
+  defp run_task(module, message, task, state, extensions) do
     task = State.transition(task, :working)
 
     context = %{
       task_id: task.id,
       context_id: task.context_id,
       history: task.history,
-      metadata: task.metadata
+      metadata: task.metadata,
+      extensions: extensions
     }
 
     meta = %{agent: module, task_id: task.id, context_id: task.context_id}

--- a/lib/a2a/agent_card.ex
+++ b/lib/a2a/agent_card.ex
@@ -24,7 +24,8 @@ defmodule A2A.AgentCard do
           optional(:streaming) => boolean(),
           optional(:push_notifications) => boolean(),
           optional(:state_transition_history) => boolean(),
-          optional(:extended_agent_card) => boolean()
+          optional(:extended_agent_card) => boolean(),
+          optional(:extensions) => [A2A.AgentExtension.t()]
         }
 
   @type provider :: %{

--- a/lib/a2a/agent_extension.ex
+++ b/lib/a2a/agent_extension.ex
@@ -1,0 +1,42 @@
+defmodule A2A.AgentExtension do
+  @moduledoc """
+  Declaration of a protocol extension supported by an agent.
+
+  Mirrors the `AgentExtension` object from the A2A v1.0 spec. Used both as a
+  struct embedded in `AgentCard.capabilities.extensions` and as the value
+  returned by an `A2A.Extension` module's `declaration/1` callback.
+
+  ## Fields
+
+    * `:uri` — unique identifier for the extension (required)
+    * `:description` — human-readable description of how the agent uses it
+    * `:required` — if `true`, clients must declare support via the
+      `A2A-Extensions` request header; otherwise the server returns
+      `ExtensionSupportRequiredError` (-32008). Defaults to `false`.
+    * `:params` — optional extension-specific configuration parameters
+
+  ## Examples
+
+      %A2A.AgentExtension{
+        uri: "https://a2a-protocol.org/extensions/timestamp",
+        description: "Adds timestamps to messages and artifacts"
+      }
+
+      %A2A.AgentExtension{
+        uri: "https://a2a-protocol.org/extensions/secure-passport",
+        description: "Personalization via signed passport",
+        required: true,
+        params: %{"version" => "1.0"}
+      }
+  """
+
+  @type t :: %__MODULE__{
+          uri: String.t(),
+          description: String.t() | nil,
+          required: boolean(),
+          params: map() | nil
+        }
+
+  @enforce_keys [:uri]
+  defstruct [:uri, :description, :params, required: false]
+end

--- a/lib/a2a/client.ex
+++ b/lib/a2a/client.ex
@@ -37,6 +37,14 @@ if Code.ensure_loaded?(Req) do
     - `:metadata` — arbitrary metadata map
     - `:headers` — additional HTTP headers
     - `:timeout` — HTTP request timeout in ms
+
+    ## Extensions
+
+    Pass `:extensions` to `new/2` to declare A2A protocol extensions this
+    client supports. Their declared URIs are sent in the `A2A-Extensions`
+    request header on every call. Use `parse_extensions_header/1` and
+    `activated/2` on the resulting `Req.Response` to find out which
+    extensions the server activated.
     """
 
     alias A2A.JSONRPC.Error
@@ -45,10 +53,11 @@ if Code.ensure_loaded?(Req) do
 
     @type t :: %__MODULE__{
             url: String.t(),
-            req: Req.Request.t()
+            req: Req.Request.t(),
+            extensions: [A2A.Extension.compiled()]
           }
 
-    defstruct [:url, :req]
+    defstruct [:url, :req, extensions: []]
 
     @doc """
     Creates a new client struct.
@@ -69,18 +78,30 @@ if Code.ensure_loaded?(Req) do
     end
 
     def new(url, opts) when is_binary(url) do
+      {ext_entries, opts} = Keyword.pop(opts, :extensions, [])
+      compiled = A2A.Extension.compile(ext_entries)
+      ext_uris = A2A.Extension.declared_uris(compiled)
+
       {req_opts, _rest} =
         Keyword.split(opts, [:headers, :connect_options, :retry, :plug])
+
+      base_headers = [{"content-type", "application/json"}]
+
+      base_headers =
+        case ext_uris do
+          [] -> base_headers
+          uris -> [{"a2a-extensions", Enum.join(uris, ", ")} | base_headers]
+        end
 
       req =
         Req.new(
           Keyword.merge(
-            [base_url: url, headers: [{"content-type", "application/json"}]],
+            [base_url: url, headers: base_headers],
             req_opts
           )
         )
 
-      %__MODULE__{url: url, req: req}
+      %__MODULE__{url: url, req: req, extensions: compiled}
     end
 
     @doc """
@@ -236,6 +257,37 @@ if Code.ensure_loaded?(Req) do
         {:ok, response} -> decode_jsonrpc_result(response, :task)
         {:error, _} = error -> error
       end
+    end
+
+    @doc """
+    Parses the `A2A-Extensions` header from a `Req.Response`. Returns the
+    list of extension URIs the server activated for the corresponding
+    request, or `[]` if the header is absent.
+
+    HTTP headers may appear as a single comma-separated value or as
+    multiple repeated headers; both are handled.
+    """
+    @spec parse_extensions_header(Req.Response.t()) :: [String.t()]
+    def parse_extensions_header(%Req.Response{headers: headers}) do
+      headers
+      |> Map.get("a2a-extensions", [])
+      |> List.wrap()
+      |> Enum.flat_map(&String.split(&1, ","))
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+    end
+
+    @doc """
+    Returns the configured extension modules whose URI appears in the
+    server's `A2A-Extensions` response header.
+    """
+    @spec activated(t(), Req.Response.t()) :: [module()]
+    def activated(%__MODULE__{extensions: compiled}, response) do
+      activated = MapSet.new(parse_extensions_header(response))
+
+      for {mod, _state, %A2A.AgentExtension{uri: uri}} <- compiled,
+          MapSet.member?(activated, uri),
+          do: mod
     end
 
     @doc """

--- a/lib/a2a/extension.ex
+++ b/lib/a2a/extension.ex
@@ -1,0 +1,349 @@
+defmodule A2A.Extension do
+  @moduledoc """
+  Behaviour for A2A v1.0 protocol extensions.
+
+  An extension module advertises a URI in its `c:declaration/1`, optionally
+  participates in per-request activation via `c:activate/3`, and can hook into
+  the request/response pipeline via `c:handle_request/3` and
+  `c:handle_response/3`. Configured on `A2A.Plug` and `A2A.Client` as a list
+  of `module()` or `{module(), keyword()}` tuples.
+
+  See the [A2A v1.0 extensions topic](https://a2a-protocol.org/dev/topics/extensions/)
+  for protocol-level semantics. This module implements the data-only and
+  profile extension categories; method extensions (registering new RPC
+  methods) and state-machine extensions are not yet supported.
+
+  ## Defining an extension
+
+      defmodule MyApp.TimestampExtension do
+        @behaviour A2A.Extension
+        @uri "https://example.com/ext/timestamp"
+
+        @impl true
+        def declaration(_state) do
+          %A2A.AgentExtension{uri: @uri, description: "Adds request timestamps"}
+        end
+
+        @impl true
+        def activate(_requested_uris, _ctx, _state) do
+          {:ok, System.system_time(:millisecond)}
+        end
+
+        @impl true
+        def handle_response(task, _params, started_at) do
+          {:ok, A2A.Extension.put_metadata(task, __MODULE__, %{started_at: started_at}),
+           started_at}
+        end
+      end
+
+  ## Activation model
+
+  At Plug/Client init time each configured extension's `c:init/1` is called
+  with its opts; the returned state is kept alongside the module. Per
+  request, the server parses the `A2A-Extensions` header and for each
+  configured extension whose declared URI is in the requested set, calls
+  `c:activate/3` with the requested URI list, the request context, and the
+  init state. `c:activate/3` may return `{:ok, activation}` to participate,
+  `:skip` to opt out for this request, or `{:error, error}` to abort with
+  a JSON-RPC error. The list of activated URIs is echoed in the response
+  `A2A-Extensions` header.
+
+  Required extensions (`required: true` in `c:declaration/1`) that are not
+  declared in the client's request header trigger
+  `ExtensionSupportRequiredError` (-32008) before activation runs.
+
+  ## Hooks
+
+  Activated extensions can mutate the request or response:
+
+  - `c:handle_request/3` — receives the decoded message, JSON-RPC params,
+    and the extension's activation. Runs in declaration order before the
+    request is dispatched to the agent.
+  - `c:handle_response/3` — receives the task, JSON-RPC params, and the
+    activation. Runs in declaration order after the agent replies and
+    before the task is encoded.
+
+  Both callbacks are optional; data-only extensions implement neither.
+
+  ## Reading activations inside an agent
+
+  Activations are surfaced to the agent's `handle_message/2` as
+  `context.extensions`, a `%{uri => activation}` map. The
+  `A2A.Extension.fetch/2` and `A2A.Extension.activated?/2` helpers look up
+  by module rather than URI string.
+  """
+
+  alias A2A.{Artifact, JSONRPC, Message, Task}
+
+  @typedoc "An extension's per-request activation value (opaque to the framework)."
+  @type activation :: term()
+
+  @typedoc "An extension's init state (returned from `c:init/1`)."
+  @type state :: term()
+
+  @typedoc "User-facing extension configuration entry."
+  @type config_entry :: module() | {module(), keyword()}
+
+  @typedoc """
+  Internal compiled extension entry. Pipeline state: the module, its init
+  state, and its (cached) declaration.
+  """
+  @type compiled :: {module(), state(), A2A.AgentExtension.t()}
+
+  @typedoc "Ordered list of activations for hook chaining."
+  @type activations :: [{module(), activation(), String.t()}]
+
+  @doc """
+  Validates and compiles the extension's options. Called once when the
+  parent plug or client is initialised. The returned value is threaded
+  back into the remaining callbacks as the `state` argument.
+
+  Defaults to ignoring opts and returning `nil`.
+  """
+  @callback init(opts :: keyword()) :: state()
+
+  @doc """
+  Returns the `%A2A.AgentExtension{}` describing this extension. The URI is
+  used both for agent-card advertisement and for matching against the
+  `A2A-Extensions` request header.
+  """
+  @callback declaration(state()) :: A2A.AgentExtension.t()
+
+  @doc """
+  Called once per request when the client has declared this extension in
+  its `A2A-Extensions` header. Returns the activation value that is
+  threaded through subsequent hooks, or `:skip` to opt out for this
+  request, or `{:error, error}` to abort the request.
+
+  Defaults to `{:ok, nil}` (always activate, no per-request state).
+  """
+  @callback activate(requested_uris :: [String.t()], ctx :: map(), state()) ::
+              {:ok, activation()} | :skip | {:error, JSONRPC.Error.t()}
+
+  @doc """
+  Optional. Mutate the inbound message or JSON-RPC params before dispatch.
+  Runs in declaration order across activated extensions.
+  """
+  @callback handle_request(Message.t(), params :: map(), activation()) ::
+              {:ok, Message.t(), params :: map(), activation()}
+              | {:error, JSONRPC.Error.t()}
+
+  @doc """
+  Optional. Mutate the outbound task before encoding. Runs in declaration
+  order across activated extensions.
+  """
+  @callback handle_response(Task.t(), params :: map(), activation()) ::
+              {:ok, Task.t(), activation()}
+
+  @optional_callbacks init: 1, activate: 3, handle_request: 3, handle_response: 3
+
+  # ---------------------------------------------------------------------------
+  # Public helpers (used by extension authors and agent code)
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Fetches the activation value for the given extension module from a
+  request context. Returns `{:ok, activation}` or `:error`.
+  """
+  @spec fetch(map(), module()) :: {:ok, activation()} | :error
+  def fetch(%{extensions: extensions}, module) when is_atom(module) do
+    Map.fetch(extensions, uri_of(module))
+  end
+
+  def fetch(_ctx, _module), do: :error
+
+  @doc """
+  Returns `true` if the given extension module is activated in the context.
+  """
+  @spec activated?(map(), module()) :: boolean()
+  def activated?(ctx, module), do: match?({:ok, _}, fetch(ctx, module))
+
+  @doc """
+  Convenience for namespacing a value under an extension's URI inside the
+  `metadata` field of a `Message`, `Artifact`, or `Task`.
+  """
+  @spec put_metadata(Message.t() | Artifact.t() | Task.t(), module(), term()) ::
+          Message.t() | Artifact.t() | Task.t()
+  def put_metadata(%Message{} = msg, module, value) do
+    %{msg | metadata: Map.put(msg.metadata || %{}, uri_of(module), value)}
+  end
+
+  def put_metadata(%Artifact{} = artifact, module, value) do
+    %{artifact | metadata: Map.put(artifact.metadata || %{}, uri_of(module), value)}
+  end
+
+  def put_metadata(%Task{} = task, module, value) do
+    %{task | metadata: Map.put(task.metadata || %{}, uri_of(module), value)}
+  end
+
+  defp uri_of(module) do
+    Code.ensure_loaded!(module)
+    state = if function_exported?(module, :init, 1), do: module.init([]), else: nil
+    module.declaration(state).uri
+  end
+
+  # ---------------------------------------------------------------------------
+  # Pipeline (used internally by A2A.Plug, A2A.JSONRPC, A2A.Client)
+  # ---------------------------------------------------------------------------
+
+  @doc false
+  @spec compile([config_entry()]) :: [compiled()]
+  def compile(entries) when is_list(entries) do
+    Enum.map(entries, &compile_entry/1)
+  end
+
+  defp compile_entry(module) when is_atom(module), do: compile_entry({module, []})
+
+  defp compile_entry({module, opts}) when is_atom(module) and is_list(opts) do
+    Code.ensure_loaded!(module)
+    state = if function_exported?(module, :init, 1), do: module.init(opts), else: nil
+    {module, state, module.declaration(state)}
+  end
+
+  @doc """
+  Parses a list of raw `A2A-Extensions` header values (HTTP allows multiple
+  values, each potentially comma-separated) into a deduplicated list of
+  requested URIs.
+  """
+  @spec parse_header([String.t()] | String.t() | nil) :: [String.t()]
+  def parse_header(nil), do: []
+  def parse_header(value) when is_binary(value), do: parse_header([value])
+
+  def parse_header(values) when is_list(values) do
+    values
+    |> Enum.flat_map(&String.split(&1, ","))
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  @doc """
+  Returns the URIs of declarations that are marked `required: true`.
+  """
+  @spec required_uris([compiled()]) :: [String.t()]
+  def required_uris(compiled) do
+    for {_mod, _state, %A2A.AgentExtension{required: true, uri: uri}} <- compiled, do: uri
+  end
+
+  @doc """
+  Returns the URIs declared by all compiled extensions, in declaration order.
+  """
+  @spec declared_uris([compiled()]) :: [String.t()]
+  def declared_uris(compiled) do
+    for {_mod, _state, %A2A.AgentExtension{uri: uri}} <- compiled, do: uri
+  end
+
+  @doc """
+  Returns the declarations of all compiled extensions, in declaration order.
+  """
+  @spec declarations([compiled()]) :: [A2A.AgentExtension.t()]
+  def declarations(compiled) do
+    for {_mod, _state, decl} <- compiled, do: decl
+  end
+
+  @doc """
+  Validates required-extension presence against the client's requested URIs.
+  Returns `:ok` or `{:error, missing_uris}`.
+  """
+  @spec validate_required([compiled()], [String.t()]) ::
+          :ok | {:error, [String.t()]}
+  def validate_required(compiled, requested) when is_list(requested) do
+    case Enum.reject(required_uris(compiled), &(&1 in requested)) do
+      [] -> :ok
+      missing -> {:error, missing}
+    end
+  end
+
+  @doc """
+  Runs `activate/3` for each configured extension whose declared URI is in
+  the requested list. Returns an ordered list of `{module, activation, uri}`
+  tuples and the matching URI list, or an error if any extension's
+  `activate/3` returned `{:error, ...}`.
+  """
+  @spec activate([compiled()], [String.t()], map()) ::
+          {:ok, activations(), [String.t()]} | {:error, JSONRPC.Error.t()}
+  def activate(compiled, requested, ctx) when is_list(requested) do
+    Enum.reduce_while(compiled, {:ok, [], []}, fn {mod, state, decl}, {:ok, acts, uris} ->
+      if decl.uri in requested do
+        case do_activate(mod, requested, ctx, state) do
+          {:ok, activation} ->
+            {:cont, {:ok, [{mod, activation, decl.uri} | acts], [decl.uri | uris]}}
+
+          :skip ->
+            {:cont, {:ok, acts, uris}}
+
+          {:error, %JSONRPC.Error{} = err} ->
+            {:halt, {:error, err}}
+        end
+      else
+        {:cont, {:ok, acts, uris}}
+      end
+    end)
+    |> case do
+      {:ok, acts, uris} -> {:ok, Enum.reverse(acts), Enum.reverse(uris)}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp do_activate(module, requested, ctx, state) do
+    if function_exported?(module, :activate, 3) do
+      module.activate(requested, ctx, state)
+    else
+      {:ok, nil}
+    end
+  end
+
+  @doc """
+  Runs the `handle_request/3` chain over an activated extension list.
+  Returns possibly-mutated message, params, and the (possibly-updated)
+  activations list, or `{:error, error}` if any extension aborted.
+  """
+  @spec run_request(activations(), Message.t(), map()) ::
+          {:ok, Message.t(), map(), activations()} | {:error, JSONRPC.Error.t()}
+  def run_request(activations, message, params) do
+    Enum.reduce_while(activations, {:ok, message, params, []}, fn {mod, act, uri},
+                                                                  {:ok, msg, p, acc} ->
+      if function_exported?(mod, :handle_request, 3) do
+        case mod.handle_request(msg, p, act) do
+          {:ok, msg2, p2, act2} -> {:cont, {:ok, msg2, p2, [{mod, act2, uri} | acc]}}
+          {:error, %JSONRPC.Error{} = err} -> {:halt, {:error, err}}
+        end
+      else
+        {:cont, {:ok, msg, p, [{mod, act, uri} | acc]}}
+      end
+    end)
+    |> case do
+      {:ok, msg, p, acc} -> {:ok, msg, p, Enum.reverse(acc)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Runs the `handle_response/3` chain over an activated extension list.
+  Returns the possibly-mutated task and the updated activations list.
+  """
+  @spec run_response(activations(), Task.t(), map()) ::
+          {:ok, Task.t(), activations()}
+  def run_response(activations, task, params) do
+    {task, acc} =
+      Enum.reduce(activations, {task, []}, fn {mod, act, uri}, {t, acc} ->
+        if function_exported?(mod, :handle_response, 3) do
+          {:ok, t2, act2} = mod.handle_response(t, params, act)
+          {t2, [{mod, act2, uri} | acc]}
+        else
+          {t, [{mod, act, uri} | acc]}
+        end
+      end)
+
+    {:ok, task, Enum.reverse(acc)}
+  end
+
+  @doc """
+  Converts the ordered activations list into the `%{uri => activation}`
+  map exposed to the agent via `context.extensions`.
+  """
+  @spec to_context_map(activations()) :: %{String.t() => activation()}
+  def to_context_map(activations) do
+    Map.new(activations, fn {_mod, act, uri} -> {uri, act} end)
+  end
+end

--- a/lib/a2a/extension.ex
+++ b/lib/a2a/extension.ex
@@ -71,6 +71,55 @@ defmodule A2A.Extension do
   `context.extensions`, a `%{uri => activation}` map. The
   `A2A.Extension.fetch/2` and `A2A.Extension.activated?/2` helpers look up
   by module rather than URI string.
+
+      def handle_message(message, context) do
+        case A2A.Extension.fetch(context, MyApp.TimestampExtension) do
+          {:ok, started_at} -> use_timestamp(message, started_at)
+          :error -> handle_without(message)
+        end
+      end
+
+  ## Configuring extensions
+
+  Server side, pass `:extensions` to `A2A.Plug`. The configured
+  declarations are merged into `capabilities.extensions` on the served
+  agent card, and the negotiation pipeline runs around every JSON-RPC
+  dispatch.
+
+      # Standalone with Bandit
+      Bandit.start_link(
+        plug: {A2A.Plug,
+          agent: MyAgent,
+          base_url: "http://localhost:4000",
+          extensions: [A2A.Extension.Timestamp, {MyApp.Passport, issuer: "acme"}]}
+      )
+
+      # Or in a Phoenix router
+      forward "/a2a", A2A.Plug,
+        agent: MyAgent,
+        base_url: "http://localhost:4000/a2a",
+        extensions: [A2A.Extension.Timestamp]
+
+  Client side, pass `:extensions` to `A2A.Client.new/2`. The configured
+  URIs are sent in the `A2A-Extensions` request header on every call.
+  `A2A.Client.parse_extensions_header/1` and
+  `A2A.Client.activated/2` read the server's response header to discover
+  which extensions actually ran.
+
+      client = A2A.Client.new("http://localhost:4000",
+        extensions: [A2A.Extension.Timestamp])
+
+      {:ok, task} = A2A.Client.send_message(client, "hi")
+      task.metadata[A2A.Extension.Timestamp.uri()]
+      #=> %{"received_at" => ..., "completed_at" => ...}
+
+  ## Reference
+
+  `A2A.Extension.Timestamp` ships in-tree as a complete profile-extension
+  example covering `c:declaration/1`, `c:activate/3`,
+  `c:handle_request/3`, and `c:handle_response/3`. See
+  [`examples/extensions.exs`](https://github.com/actioncard/a2a-elixir/blob/main/examples/extensions.exs)
+  for an end-to-end runnable demo.
   """
 
   alias A2A.{Artifact, JSONRPC, Message, Task}

--- a/lib/a2a/extension/timestamp.ex
+++ b/lib/a2a/extension/timestamp.ex
@@ -1,0 +1,89 @@
+defmodule A2A.Extension.Timestamp do
+  @moduledoc """
+  Reference `A2A.Extension` that timestamps requests and responses.
+
+  Stamps `Message.metadata` on the way in and `Task.metadata` on the way
+  out under the extension's URI:
+
+      "https://a2a-protocol.org/extensions/timestamp/v1" => %{
+        received_at: 1_700_000_000_000,
+        completed_at: 1_700_000_000_042
+      }
+
+  Times are wall-clock milliseconds via `System.system_time(:millisecond)`.
+
+  ## Usage
+
+  Configure on the server and (optionally) on the client. Both must declare
+  the URI for the activation to round-trip.
+
+      # Server
+      Bandit.start_link(
+        plug: {A2A.Plug,
+          agent: MyAgent,
+          base_url: "http://localhost:4000",
+          extensions: [A2A.Extension.Timestamp]}
+      )
+
+      # Client
+      client = A2A.Client.new("http://localhost:4000",
+        extensions: [A2A.Extension.Timestamp])
+
+      {:ok, task} = A2A.Client.send_message(client, "hi")
+      task.metadata["https://a2a-protocol.org/extensions/timestamp/v1"]
+      #=> %{"received_at" => 1700000000000, "completed_at" => 1700000000042}
+
+  Map keys are atoms on the server (before encoding) and strings on the
+  client (after JSON decode).
+
+  ## What this exercises
+
+  This module implements every optional callback of `A2A.Extension`:
+
+    * `c:A2A.Extension.declaration/1` — non-required profile extension.
+    * `c:A2A.Extension.activate/3` — captures the per-request start time.
+    * `c:A2A.Extension.handle_request/3` — stamps the inbound message metadata.
+    * `c:A2A.Extension.handle_response/3` — stamps the outbound task metadata.
+
+  Copy it as a starting template for your own profile-style extension.
+  """
+
+  @behaviour A2A.Extension
+
+  @uri "https://a2a-protocol.org/extensions/timestamp/v1"
+
+  @typedoc """
+  Activation state: the wall-clock millisecond when the request was first
+  observed by the server.
+  """
+  @type activation :: %{received_at: integer()}
+
+  @doc "The stable URI advertised by this extension."
+  @spec uri() :: String.t()
+  def uri, do: @uri
+
+  @impl A2A.Extension
+  def declaration(_state) do
+    %A2A.AgentExtension{
+      uri: @uri,
+      description: "Stamps requests and responses with wall-clock milliseconds."
+    }
+  end
+
+  @impl A2A.Extension
+  def activate(_requested, _ctx, _state) do
+    {:ok, %{received_at: System.system_time(:millisecond)}}
+  end
+
+  @impl A2A.Extension
+  def handle_request(message, params, %{received_at: t} = activation) do
+    message = A2A.Extension.put_metadata(message, __MODULE__, %{received_at: t})
+    {:ok, message, params, activation}
+  end
+
+  @impl A2A.Extension
+  def handle_response(task, _params, %{received_at: t} = activation) do
+    stamp = %{received_at: t, completed_at: System.system_time(:millisecond)}
+    {:ok, A2A.Extension.put_metadata(task, __MODULE__, stamp), activation}
+  end
+end

--- a/lib/a2a/json.ex
+++ b/lib/a2a/json.ex
@@ -561,12 +561,24 @@ defmodule A2A.JSON do
   end
 
   defp encode_capabilities(caps) when is_map(caps) do
-    encode_known_keys(caps, [
+    caps
+    |> encode_known_keys([
       {"streaming", :streaming},
       {"pushNotifications", :push_notifications},
       {"stateTransitionHistory", :state_transition_history},
       {"extendedAgentCard", :extended_agent_card}
     ])
+    |> put_unless_empty("extensions", encode_agent_extensions(Map.get(caps, :extensions, [])))
+  end
+
+  defp encode_agent_extensions(extensions) when is_list(extensions) do
+    Enum.map(extensions, &encode_agent_extension/1)
+  end
+
+  defp encode_agent_extension(%A2A.AgentExtension{} = ext) do
+    %{"uri" => ext.uri, "required" => ext.required}
+    |> put_unless_nil("description", ext.description)
+    |> put_unless_nil("params", ext.params)
   end
 
   defp encode_interfaces(interfaces) when is_list(interfaces) do
@@ -804,12 +816,30 @@ defmodule A2A.JSON do
   defp decode_card_capabilities(nil), do: %{}
 
   defp decode_card_capabilities(map) when is_map(map) do
-    decode_known_keys(map, [
-      {"streaming", :streaming},
-      {"pushNotifications", :push_notifications},
-      {"stateTransitionHistory", :state_transition_history},
-      {"extendedAgentCard", :extended_agent_card}
-    ])
+    base =
+      decode_known_keys(map, [
+        {"streaming", :streaming},
+        {"pushNotifications", :push_notifications},
+        {"stateTransitionHistory", :state_transition_history},
+        {"extendedAgentCard", :extended_agent_card}
+      ])
+
+    case Map.get(map, "extensions") do
+      list when is_list(list) and list != [] ->
+        Map.put(base, :extensions, Enum.map(list, &decode_agent_extension/1))
+
+      _ ->
+        base
+    end
+  end
+
+  defp decode_agent_extension(map) when is_map(map) do
+    %A2A.AgentExtension{
+      uri: Map.fetch!(map, "uri"),
+      description: Map.get(map, "description"),
+      required: Map.get(map, "required", false),
+      params: Map.get(map, "params")
+    }
   end
 
   defp decode_card_interfaces(interfaces) when is_list(interfaces) do

--- a/lib/a2a/plug.ex
+++ b/lib/a2a/plug.ex
@@ -36,6 +36,14 @@ if Code.ensure_loaded?(Plug) do
       operations. Called as `(operation, task, context)` before returning,
       canceling, or listing tasks. Denied `tasks/get` and `tasks/cancel`
       requests return `TaskNotFoundError` so task IDs are not leaked.
+    - `:extensions` — list of `A2A.Extension` modules (or `{module, opts}`
+      tuples) declaring protocol extensions this server supports. Required
+      extensions are validated against the client's `A2A-Extensions`
+      request header; missing required extensions return
+      `ExtensionSupportRequiredError` (-32008). The server sets the
+      `A2A-Extensions` response header to the URIs that were activated.
+      Declarations are merged into `capabilities.extensions` on the
+      served agent card.
 
     ## Per-Request Overrides
 
@@ -121,7 +129,8 @@ if Code.ensure_loaded?(Plug) do
         json_rpc_path: Keyword.get(opts, :json_rpc_path, []),
         agent_card_opts: Keyword.get(opts, :agent_card_opts, []),
         metadata: Keyword.get(opts, :metadata, %{}),
-        authorize_task: Keyword.get(opts, :authorize_task)
+        authorize_task: Keyword.get(opts, :authorize_task),
+        extensions: A2A.Extension.compile(Keyword.get(opts, :extensions, []))
       }
     end
 
@@ -176,11 +185,12 @@ if Code.ensure_loaded?(Plug) do
 
     defp serve_agent_card(conn, opts) do
       card = GenServer.call(opts.agent, :get_agent_card)
+      agent_card_opts = merge_extension_declarations(opts.agent_card_opts, opts.extensions)
 
       json =
         A2A.JSON.encode_agent_card(
           card,
-          [url: opts.base_url] ++ opts.agent_card_opts
+          [url: opts.base_url] ++ agent_card_opts
         )
 
       conn
@@ -188,12 +198,57 @@ if Code.ensure_loaded?(Plug) do
       |> send_resp(200, Jason.encode!(json))
     end
 
+    defp merge_extension_declarations(agent_card_opts, []), do: agent_card_opts
+
+    defp merge_extension_declarations(agent_card_opts, compiled) do
+      caps = Keyword.get(agent_card_opts, :capabilities, %{})
+      existing = Map.get(caps, :extensions, [])
+      existing_uris = MapSet.new(existing, & &1.uri)
+
+      new =
+        compiled
+        |> A2A.Extension.declarations()
+        |> Enum.reject(&MapSet.member?(existing_uris, &1.uri))
+
+      caps = Map.put(caps, :extensions, existing ++ new)
+      Keyword.put(agent_card_opts, :capabilities, caps)
+    end
+
     # -- JSON-RPC dispatch -----------------------------------------------------
 
     defp handle_json_rpc(conn, opts) do
+      requested = A2A.Extension.parse_header(get_req_header(conn, "a2a-extensions"))
+
+      with :ok <- A2A.Extension.validate_required(opts.extensions, requested),
+           {:ok, activations, activated_uris} <-
+             A2A.Extension.activate(opts.extensions, requested, %{conn: conn}) do
+        conn = put_extensions_response_header(conn, activated_uris)
+        dispatch_json_rpc(conn, opts, activations)
+      else
+        {:error, missing} when is_list(missing) ->
+          send_json(
+            conn,
+            Response.error(
+              nil,
+              Error.extension_support_required(
+                "Client missing required extensions: " <> Enum.join(missing, ", ")
+              )
+            )
+          )
+
+        {:error, %Error{} = err} ->
+          send_json(conn, Response.error(nil, err))
+      end
+    end
+
+    defp dispatch_json_rpc(conn, opts, activations) do
       case read_json_body(conn) do
         {:ok, decoded, conn} ->
-          context = %{agent: opts.agent, opts: opts}
+          context = %{
+            agent: opts.agent,
+            opts: opts,
+            extensions: activations
+          }
 
           case A2A.JSONRPC.handle(decoded, __MODULE__, context) do
             {:reply, response} ->
@@ -207,6 +262,7 @@ if Code.ensure_loaded?(Plug) do
                 |> build_call_opts(opts)
                 |> maybe_put_fallback(:task_id, message.task_id)
                 |> maybe_put_fallback(:context_id, message.context_id)
+                |> Keyword.put(:extensions, A2A.Extension.to_context_map(activations))
 
               A2A.Plug.SSE.stream_message(
                 conn,
@@ -229,6 +285,12 @@ if Code.ensure_loaded?(Plug) do
         {:error, reason} ->
           send_json(conn, Response.error(nil, Error.internal_error(inspect(reason))))
       end
+    end
+
+    defp put_extensions_response_header(conn, []), do: conn
+
+    defp put_extensions_response_header(conn, uris) do
+      put_resp_header(conn, "a2a-extensions", Enum.join(uris, ", "))
     end
 
     # Returns the decoded JSON body, handling both pre-parsed (Phoenix with
@@ -262,16 +324,27 @@ if Code.ensure_loaded?(Plug) do
     # -- JSONRPC behaviour callbacks -------------------------------------------
 
     @impl A2A.JSONRPC
-    def handle_send(message, params, %{agent: agent, opts: plug_opts}) do
-      call_opts =
-        params
-        |> build_call_opts(plug_opts)
-        |> maybe_put_fallback(:task_id, message.task_id)
-        |> maybe_put_fallback(:context_id, message.context_id)
+    def handle_send(message, params, ctx) do
+      %{agent: agent, opts: plug_opts} = ctx
+      activations = Map.get(ctx, :extensions, [])
 
-      case A2A.call(agent, message, call_opts) do
-        {:ok, task} -> {:ok, task}
-        {:error, reason} -> {:error, Error.internal_error(inspect(reason))}
+      with {:ok, message, params, activations} <-
+             A2A.Extension.run_request(activations, message, params) do
+        call_opts =
+          params
+          |> build_call_opts(plug_opts)
+          |> maybe_put_fallback(:task_id, message.task_id)
+          |> maybe_put_fallback(:context_id, message.context_id)
+          |> Keyword.put(:extensions, A2A.Extension.to_context_map(activations))
+
+        case A2A.call(agent, message, call_opts) do
+          {:ok, task} ->
+            {:ok, task, _activations} = A2A.Extension.run_response(activations, task, params)
+            {:ok, task}
+
+          {:error, reason} ->
+            {:error, Error.internal_error(inspect(reason))}
+        end
       end
     end
 

--- a/test/a2a/agent_extension_test.exs
+++ b/test/a2a/agent_extension_test.exs
@@ -1,0 +1,31 @@
+defmodule A2A.AgentExtensionTest do
+  use ExUnit.Case, async: true
+
+  alias A2A.AgentExtension
+
+  test "defaults required to false and other fields to nil" do
+    ext = %AgentExtension{uri: "https://example.com/ext/a"}
+    assert ext.uri == "https://example.com/ext/a"
+    assert ext.required == false
+    assert ext.description == nil
+    assert ext.params == nil
+  end
+
+  test "accepts all fields" do
+    ext = %AgentExtension{
+      uri: "https://example.com/ext/b",
+      description: "Test",
+      required: true,
+      params: %{"version" => "1.0"}
+    }
+
+    assert ext.required == true
+    assert ext.params == %{"version" => "1.0"}
+  end
+
+  test "enforces :uri" do
+    assert_raise ArgumentError, fn ->
+      struct!(AgentExtension, %{description: "no uri"})
+    end
+  end
+end

--- a/test/a2a/client_extension_test.exs
+++ b/test/a2a/client_extension_test.exs
@@ -1,0 +1,164 @@
+defmodule A2A.ClientExtensionTest do
+  use ExUnit.Case, async: true
+
+  alias A2A.Client
+  alias A2A.Test.Extensions.{Passport, Timestamp}
+
+  @task_json %{
+    "kind" => "task",
+    "id" => "tsk-1",
+    "status" => %{"state" => "TASK_STATE_COMPLETED"},
+    "history" => [
+      %{"messageId" => "m1", "role" => "ROLE_USER", "parts" => [%{"text" => "hi"}]},
+      %{"messageId" => "m2", "role" => "ROLE_AGENT", "parts" => [%{"text" => "ok"}]}
+    ],
+    "artifacts" => [%{"parts" => [%{"text" => "ok"}]}]
+  }
+
+  defp jsonrpc_success(result, id \\ 1) do
+    %{"jsonrpc" => "2.0", "id" => id, "result" => result}
+  end
+
+  defp json_resp(conn, status, body, headers \\ []) do
+    conn =
+      Enum.reduce(headers, conn, fn {k, v}, c -> Plug.Conn.put_resp_header(c, k, v) end)
+
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(status, Jason.encode!(body))
+  end
+
+  describe "new/2 :extensions option" do
+    test "stores compiled extensions and sets A2A-Extensions request header" do
+      received = self()
+
+      plug = fn conn ->
+        send(received, {:headers, conn.req_headers})
+        json_resp(conn, 200, jsonrpc_success(%{"task" => @task_json}))
+      end
+
+      client =
+        Client.new("https://agent.example.com",
+          extensions: [Timestamp, {Passport, issuer: "acme"}],
+          plug: plug
+        )
+
+      assert length(client.extensions) == 2
+      assert {:ok, _task} = Client.send_message(client, "hi")
+
+      assert_received {:headers, headers}
+
+      [{"a2a-extensions", value}] =
+        Enum.filter(headers, fn {k, _} -> k == "a2a-extensions" end)
+
+      uris = value |> String.split(",") |> Enum.map(&String.trim/1)
+      assert "https://example.test/ext/timestamp" in uris
+      assert "https://example.test/ext/passport" in uris
+    end
+
+    test "does not set the header when no extensions configured" do
+      received = self()
+
+      plug = fn conn ->
+        send(received, {:headers, conn.req_headers})
+        json_resp(conn, 200, jsonrpc_success(%{"task" => @task_json}))
+      end
+
+      client = Client.new("https://agent.example.com", plug: plug)
+      assert client.extensions == []
+      assert {:ok, _task} = Client.send_message(client, "hi")
+
+      assert_received {:headers, headers}
+      refute Enum.any?(headers, fn {k, _} -> k == "a2a-extensions" end)
+    end
+  end
+
+  describe "parse_extensions_header/1 and activated/2" do
+    test "parses comma-separated header values" do
+      response = %Req.Response{
+        headers: %{"a2a-extensions" => ["https://example.test/ext/timestamp"]}
+      }
+
+      assert Client.parse_extensions_header(response) ==
+               ["https://example.test/ext/timestamp"]
+    end
+
+    test "parses multi-value header" do
+      response = %Req.Response{
+        headers: %{
+          "a2a-extensions" => [
+            "https://example.test/ext/timestamp, https://example.test/ext/passport"
+          ]
+        }
+      }
+
+      assert Client.parse_extensions_header(response) == [
+               "https://example.test/ext/timestamp",
+               "https://example.test/ext/passport"
+             ]
+    end
+
+    test "returns [] when header absent" do
+      response = %Req.Response{headers: %{}}
+      assert Client.parse_extensions_header(response) == []
+    end
+
+    test "activated/2 returns the subset of configured modules echoed by server" do
+      client =
+        Client.new("https://agent.example.com",
+          extensions: [Timestamp, Passport]
+        )
+
+      response = %Req.Response{
+        headers: %{"a2a-extensions" => ["https://example.test/ext/timestamp"]}
+      }
+
+      assert Client.activated(client, response) == [Timestamp]
+    end
+  end
+
+  describe "round-trip against A2A.Plug" do
+    setup do
+      agent = start_supervised!({A2A.Test.EchoAgent, [name: nil]})
+      {:ok, agent: agent}
+    end
+
+    test "client header reaches server, server echoes activated URI", %{agent: agent} do
+      plug_opts =
+        A2A.Plug.init(
+          agent: agent,
+          base_url: "http://localhost:4000",
+          extensions: [Timestamp]
+        )
+
+      plug_fn = fn conn -> A2A.Plug.call(conn, plug_opts) end
+
+      client =
+        Client.new("http://localhost:4000",
+          extensions: [Timestamp],
+          plug: plug_fn
+        )
+
+      assert {:ok, task} = Client.send_message(client, "hi")
+
+      # The Timestamp extension's handle_response wrote into task metadata
+      assert task.metadata["https://example.test/ext/timestamp"] ==
+               %{"finished_at" => 1_700_000_000_000}
+    end
+
+    test "required server extension missing on client triggers -32008", %{agent: agent} do
+      plug_opts =
+        A2A.Plug.init(
+          agent: agent,
+          base_url: "http://localhost:4000",
+          extensions: [Passport]
+        )
+
+      plug_fn = fn conn -> A2A.Plug.call(conn, plug_opts) end
+      client = Client.new("http://localhost:4000", plug: plug_fn)
+
+      assert {:error, %A2A.JSONRPC.Error{code: -32_008}} =
+               Client.send_message(client, "hi")
+    end
+  end
+end

--- a/test/a2a/extension/timestamp_test.exs
+++ b/test/a2a/extension/timestamp_test.exs
@@ -1,0 +1,75 @@
+defmodule A2A.Extension.TimestampTest do
+  use ExUnit.Case, async: true
+
+  alias A2A.Client
+  alias A2A.Extension.Timestamp
+
+  setup do
+    agent = start_supervised!({A2A.Test.EchoAgent, [name: nil]})
+    {:ok, agent: agent}
+  end
+
+  test "uri/0 returns the stable public URI" do
+    assert Timestamp.uri() == "https://a2a-protocol.org/extensions/timestamp/v1"
+  end
+
+  test "declares a non-required AgentExtension" do
+    %A2A.AgentExtension{uri: uri, required: false, description: desc} =
+      Timestamp.declaration(nil)
+
+    assert uri == Timestamp.uri()
+    assert is_binary(desc)
+  end
+
+  test "round-trips through Plug and Client", %{agent: agent} do
+    plug_opts =
+      A2A.Plug.init(
+        agent: agent,
+        base_url: "http://localhost:4000",
+        extensions: [Timestamp]
+      )
+
+    plug_fn = fn conn -> A2A.Plug.call(conn, plug_opts) end
+
+    client =
+      Client.new("http://localhost:4000",
+        extensions: [Timestamp],
+        plug: plug_fn
+      )
+
+    before_ms = System.system_time(:millisecond)
+    {:ok, task} = Client.send_message(client, "hi")
+    after_ms = System.system_time(:millisecond)
+
+    stamp = task.metadata[Timestamp.uri()]
+    assert is_map(stamp)
+    assert is_integer(stamp["received_at"])
+    assert is_integer(stamp["completed_at"])
+
+    assert stamp["received_at"] >= before_ms
+    assert stamp["completed_at"] >= stamp["received_at"]
+    assert stamp["completed_at"] <= after_ms
+  end
+
+  test "agent card advertises the extension", %{agent: agent} do
+    opts =
+      A2A.Plug.init(
+        agent: agent,
+        base_url: "http://localhost:4000",
+        extensions: [Timestamp]
+      )
+
+    conn =
+      Plug.Test.conn(:get, "/.well-known/agent-card.json")
+      |> A2A.Plug.call(opts)
+
+    card = Jason.decode!(conn.resp_body)
+
+    assert [
+             %{
+               "uri" => "https://a2a-protocol.org/extensions/timestamp/v1",
+               "required" => false
+             }
+           ] = card["capabilities"]["extensions"]
+  end
+end

--- a/test/a2a/extension_test.exs
+++ b/test/a2a/extension_test.exs
@@ -1,0 +1,262 @@
+defmodule A2A.ExtensionTest do
+  use ExUnit.Case, async: true
+
+  alias A2A.{AgentExtension, Extension}
+  alias A2A.Test.Extensions.{DataOnly, Passport, SkipMe, Timestamp}
+
+  describe "compile/1" do
+    test "accepts plain module and {module, opts}" do
+      [{Timestamp, _state, decl1}, {Passport, "acme", decl2}] =
+        Extension.compile([Timestamp, {Passport, issuer: "acme"}])
+
+      assert decl1.uri == "https://example.test/ext/timestamp"
+      assert decl2.uri == "https://example.test/ext/passport"
+      assert decl2.required == true
+    end
+
+    test "calls init/1 with the provided opts when defined" do
+      [{_mod, state, _decl}] = Extension.compile([{Passport, issuer: "issuer-a"}])
+      assert state == "issuer-a"
+    end
+
+    test "defaults state to nil for modules without init/1" do
+      [{Timestamp, state, _decl}] = Extension.compile([Timestamp])
+      assert state == nil
+    end
+  end
+
+  describe "parse_header/1" do
+    test "handles nil, string, and list-of-strings forms" do
+      assert Extension.parse_header(nil) == []
+      assert Extension.parse_header("a, b , c") == ["a", "b", "c"]
+      assert Extension.parse_header(["a, b", "c"]) == ["a", "b", "c"]
+      assert Extension.parse_header([""]) == []
+    end
+  end
+
+  describe "validate_required/2" do
+    test ":ok when no required extensions" do
+      compiled = Extension.compile([Timestamp])
+      assert :ok == Extension.validate_required(compiled, [])
+    end
+
+    test ":ok when required URI is in requested set" do
+      compiled = Extension.compile([Passport])
+
+      assert :ok ==
+               Extension.validate_required(
+                 compiled,
+                 ["https://example.test/ext/passport"]
+               )
+    end
+
+    test "returns missing URIs when required absent" do
+      compiled = Extension.compile([Passport, Timestamp])
+
+      assert {:error, ["https://example.test/ext/passport"]} =
+               Extension.validate_required(compiled, [])
+    end
+  end
+
+  describe "activate/3" do
+    test "activates only extensions whose URI is in the requested set, in order" do
+      compiled = Extension.compile([Timestamp, Passport])
+
+      {:ok, activations, uris} =
+        Extension.activate(
+          compiled,
+          [
+            "https://example.test/ext/passport",
+            "https://example.test/ext/timestamp"
+          ],
+          %{}
+        )
+
+      assert [{Timestamp, _, _}, {Passport, %{issuer: "default"}, _}] = activations
+
+      assert uris == [
+               "https://example.test/ext/timestamp",
+               "https://example.test/ext/passport"
+             ]
+    end
+
+    test "omits extensions whose activate/3 returns :skip" do
+      compiled = Extension.compile([SkipMe, Timestamp])
+
+      {:ok, activations, uris} =
+        Extension.activate(
+          compiled,
+          [
+            "https://example.test/ext/skip",
+            "https://example.test/ext/timestamp"
+          ],
+          %{}
+        )
+
+      assert Enum.map(activations, fn {m, _, _} -> m end) == [Timestamp]
+      assert uris == ["https://example.test/ext/timestamp"]
+    end
+
+    test "defaults to {:ok, nil} when activate/3 is not defined" do
+      compiled = Extension.compile([DataOnly])
+
+      {:ok, [{DataOnly, nil, _}], ["https://example.test/ext/data-only"]} =
+        Extension.activate(
+          compiled,
+          ["https://example.test/ext/data-only"],
+          %{}
+        )
+    end
+
+    test "propagates {:error, jsonrpc_error} from activate/3" do
+      defmodule ErroringExt do
+        @moduledoc false
+        @behaviour A2A.Extension
+        def declaration(_), do: %A2A.AgentExtension{uri: "https://example.test/ext/err"}
+        def activate(_, _, _), do: {:error, A2A.JSONRPC.Error.invalid_request("nope")}
+      end
+
+      compiled = Extension.compile([ErroringExt])
+
+      assert {:error, %A2A.JSONRPC.Error{code: -32_600, data: "nope"}} =
+               Extension.activate(
+                 compiled,
+                 ["https://example.test/ext/err"],
+                 %{}
+               )
+    end
+  end
+
+  describe "run_request/3 and run_response/3" do
+    test "chains handle_request mutations in order" do
+      compiled = Extension.compile([Timestamp])
+
+      {:ok, activations, _} =
+        Extension.activate(
+          compiled,
+          ["https://example.test/ext/timestamp"],
+          %{}
+        )
+
+      message = A2A.Message.new_user([A2A.Part.Text.new("hi")])
+
+      {:ok, message2, _params, _acts} = Extension.run_request(activations, message, %{})
+
+      assert %{"https://example.test/ext/timestamp" => %{seen_at: 1_700_000_000_000}} =
+               message2.metadata
+    end
+
+    test "chains handle_response mutations in order" do
+      compiled = Extension.compile([Timestamp])
+
+      {:ok, activations, _} =
+        Extension.activate(
+          compiled,
+          ["https://example.test/ext/timestamp"],
+          %{}
+        )
+
+      task = A2A.Task.new()
+
+      {:ok, task2, _} = Extension.run_response(activations, task, %{})
+
+      assert %{"https://example.test/ext/timestamp" => %{finished_at: 1_700_000_000_000}} =
+               task2.metadata
+    end
+
+    test "skips hooks for extensions that don't define them" do
+      compiled = Extension.compile([DataOnly])
+
+      {:ok, activations, _} =
+        Extension.activate(
+          compiled,
+          ["https://example.test/ext/data-only"],
+          %{}
+        )
+
+      message = A2A.Message.new_user([A2A.Part.Text.new("hi")])
+      task = A2A.Task.new()
+
+      assert {:ok, ^message, %{}, ^activations} = Extension.run_request(activations, message, %{})
+      assert {:ok, ^task, ^activations} = Extension.run_response(activations, task, %{})
+    end
+  end
+
+  describe "helpers" do
+    test "to_context_map/1 keys activations by URI" do
+      activations = [
+        {Timestamp, %{started_at: 1}, "https://example.test/ext/timestamp"},
+        {Passport, %{issuer: "x"}, "https://example.test/ext/passport"}
+      ]
+
+      assert Extension.to_context_map(activations) == %{
+               "https://example.test/ext/timestamp" => %{started_at: 1},
+               "https://example.test/ext/passport" => %{issuer: "x"}
+             }
+    end
+
+    test "fetch/2 looks up activation by module" do
+      ctx = %{
+        extensions: %{
+          "https://example.test/ext/timestamp" => %{started_at: 1}
+        }
+      }
+
+      assert Extension.fetch(ctx, Timestamp) == {:ok, %{started_at: 1}}
+      assert Extension.fetch(ctx, Passport) == :error
+      assert Extension.fetch(%{}, Timestamp) == :error
+    end
+
+    test "activated?/2 is boolean sugar over fetch" do
+      ctx = %{
+        extensions: %{"https://example.test/ext/timestamp" => nil}
+      }
+
+      assert Extension.activated?(ctx, Timestamp)
+      refute Extension.activated?(ctx, Passport)
+    end
+
+    test "put_metadata/3 namespaces a value under the extension URI" do
+      message = A2A.Message.new_user([A2A.Part.Text.new("hi")])
+      message = Extension.put_metadata(message, Timestamp, %{seen: true})
+
+      assert message.metadata == %{
+               "https://example.test/ext/timestamp" => %{seen: true}
+             }
+
+      task = A2A.Task.new()
+      task = Extension.put_metadata(task, Timestamp, %{done: true})
+
+      assert task.metadata == %{
+               "https://example.test/ext/timestamp" => %{done: true}
+             }
+    end
+  end
+
+  describe "declarations/1 and required_uris/1" do
+    test "returns declarations in input order" do
+      compiled = Extension.compile([Timestamp, Passport, DataOnly])
+
+      assert Enum.map(Extension.declarations(compiled), & &1.uri) == [
+               "https://example.test/ext/timestamp",
+               "https://example.test/ext/passport",
+               "https://example.test/ext/data-only"
+             ]
+
+      assert Extension.required_uris(compiled) == ["https://example.test/ext/passport"]
+
+      assert Extension.declared_uris(compiled) == [
+               "https://example.test/ext/timestamp",
+               "https://example.test/ext/passport",
+               "https://example.test/ext/data-only"
+             ]
+    end
+
+    test "embeds AgentExtension structs" do
+      compiled = Extension.compile([DataOnly])
+
+      assert [%AgentExtension{uri: "https://example.test/ext/data-only", params: %{}}] =
+               Extension.declarations(compiled)
+    end
+  end
+end

--- a/test/a2a/json_test.exs
+++ b/test/a2a/json_test.exs
@@ -1362,6 +1362,53 @@ defmodule A2A.JSONTest do
 
       assert map["capabilities"]["extendedAgentCard"] == true
     end
+
+    test "encodes capabilities.extensions" do
+      card = %{name: "x", description: "x", version: "1", skills: [], opts: []}
+
+      extensions = [
+        %A2A.AgentExtension{
+          uri: "https://example.com/ext/timestamp",
+          description: "Adds timestamps"
+        },
+        %A2A.AgentExtension{
+          uri: "https://example.com/ext/passport",
+          required: true,
+          params: %{"version" => "1.0"}
+        }
+      ]
+
+      map =
+        JSON.encode_agent_card(card,
+          url: "https://example.com",
+          capabilities: %{extensions: extensions}
+        )
+
+      assert map["capabilities"]["extensions"] == [
+               %{
+                 "uri" => "https://example.com/ext/timestamp",
+                 "required" => false,
+                 "description" => "Adds timestamps"
+               },
+               %{
+                 "uri" => "https://example.com/ext/passport",
+                 "required" => true,
+                 "params" => %{"version" => "1.0"}
+               }
+             ]
+    end
+
+    test "omits capabilities.extensions when empty" do
+      card = %{name: "x", description: "x", version: "1", skills: [], opts: []}
+
+      map =
+        JSON.encode_agent_card(card,
+          url: "https://example.com",
+          capabilities: %{extensions: []}
+        )
+
+      refute Map.has_key?(map["capabilities"], "extensions")
+    end
   end
 
   describe "decode_agent_card with security schemes" do
@@ -1443,6 +1490,65 @@ defmodule A2A.JSONTest do
 
       {:ok, card} = JSON.decode_agent_card(map)
       assert card.capabilities.extended_agent_card == true
+    end
+
+    test "decodes capabilities.extensions" do
+      map = %{
+        "name" => "x",
+        "description" => "x",
+        "url" => "https://example.com",
+        "version" => "1",
+        "skills" => [],
+        "capabilities" => %{
+          "extensions" => [
+            %{
+              "uri" => "https://example.com/ext/timestamp",
+              "description" => "Adds timestamps",
+              "required" => false
+            },
+            %{
+              "uri" => "https://example.com/ext/passport",
+              "required" => true,
+              "params" => %{"version" => "1.0"}
+            }
+          ]
+        }
+      }
+
+      {:ok, card} = JSON.decode_agent_card(map)
+
+      assert card.capabilities.extensions == [
+               %A2A.AgentExtension{
+                 uri: "https://example.com/ext/timestamp",
+                 description: "Adds timestamps",
+                 required: false
+               },
+               %A2A.AgentExtension{
+                 uri: "https://example.com/ext/passport",
+                 required: true,
+                 params: %{"version" => "1.0"}
+               }
+             ]
+    end
+
+    test "roundtrips capabilities.extensions" do
+      card = %{name: "x", description: "x", version: "1", skills: [], opts: []}
+
+      extensions = [
+        %A2A.AgentExtension{uri: "https://example.com/ext/a", description: "A"},
+        %A2A.AgentExtension{uri: "https://example.com/ext/b", required: true}
+      ]
+
+      encoded =
+        JSON.encode_agent_card(card,
+          url: "https://example.com",
+          capabilities: %{streaming: true, extensions: extensions}
+        )
+
+      {:ok, decoded} = JSON.decode_agent_card(encoded)
+
+      assert decoded.capabilities.streaming == true
+      assert decoded.capabilities.extensions == extensions
     end
 
     test "roundtrip with security schemes" do

--- a/test/a2a/plug_extension_test.exs
+++ b/test/a2a/plug_extension_test.exs
@@ -1,0 +1,262 @@
+defmodule A2A.PlugExtensionTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :plug
+
+  alias A2A.Test.Extensions.{DataOnly, Passport, Timestamp}
+
+  defp plug_opts(agent, extra \\ []) do
+    A2A.Plug.init([agent: agent, base_url: "http://localhost:4000"] ++ extra)
+  end
+
+  defp json_rpc_conn(method, params) do
+    body =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => method,
+        "params" => params
+      })
+
+    Plug.Test.conn(:post, "/", body)
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+  end
+
+  defp message_params(text \\ "hello") do
+    %{
+      "message" => %{
+        "messageId" => "msg-test",
+        "role" => "user",
+        "parts" => [%{"kind" => "text", "text" => text}]
+      }
+    }
+  end
+
+  defp json_body(conn), do: Jason.decode!(conn.resp_body)
+  defp get_resp_header(conn, key), do: for({k, v} <- conn.resp_headers, k == key, do: v)
+
+  setup do
+    agent = start_supervised!({A2A.Test.EchoAgent, [name: nil]})
+    {:ok, agent: agent}
+  end
+
+  describe "no extensions configured" do
+    test "requests succeed without A2A-Extensions header", %{agent: agent} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> A2A.Plug.call(plug_opts(agent))
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "a2a-extensions") == []
+    end
+  end
+
+  describe "optional extension activation" do
+    setup %{agent: agent} do
+      opts = plug_opts(agent, extensions: [Timestamp])
+      {:ok, opts: opts}
+    end
+
+    test "does not activate when client omits the header", %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> A2A.Plug.call(opts)
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "a2a-extensions") == []
+    end
+
+    test "activates and echoes the URI when client declares it", %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> Plug.Conn.put_req_header(
+          "a2a-extensions",
+          "https://example.test/ext/timestamp"
+        )
+        |> A2A.Plug.call(opts)
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "a2a-extensions") == ["https://example.test/ext/timestamp"]
+
+      # handle_response mutated task metadata under the URI
+      task = json_body(conn)["result"]["task"]
+
+      assert task["metadata"]["https://example.test/ext/timestamp"] ==
+               %{"finished_at" => 1_700_000_000_000}
+    end
+
+    test "handle_request runs and may mutate the message", %{opts: opts} do
+      # Reuses the same hook chain — the message has put_metadata applied
+      # before reaching the agent. The agent doesn't see it directly in
+      # this echo test, but the request hook returned :ok so the round
+      # trip succeeds.
+      conn =
+        json_rpc_conn("message/send", message_params("hi"))
+        |> Plug.Conn.put_req_header("a2a-extensions", "https://example.test/ext/timestamp")
+        |> A2A.Plug.call(opts)
+
+      assert conn.status == 200
+      assert json_body(conn)["result"]["task"]["status"]["state"] == "TASK_STATE_COMPLETED"
+    end
+  end
+
+  describe "required extension validation" do
+    setup %{agent: agent} do
+      opts = plug_opts(agent, extensions: [Passport, Timestamp])
+      {:ok, opts: opts}
+    end
+
+    test "returns -32008 when client misses required URI", %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> A2A.Plug.call(opts)
+
+      body = json_body(conn)
+      assert body["error"]["code"] == -32_008
+      assert body["error"]["data"] =~ "https://example.test/ext/passport"
+    end
+
+    test "succeeds when required URI is in client header", %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> Plug.Conn.put_req_header(
+          "a2a-extensions",
+          "https://example.test/ext/passport, https://example.test/ext/timestamp"
+        )
+        |> A2A.Plug.call(opts)
+
+      assert conn.status == 200
+      body = json_body(conn)
+      assert body["result"]["task"]["status"]["state"] == "TASK_STATE_COMPLETED"
+
+      activated = hd(get_resp_header(conn, "a2a-extensions")) |> String.split(", ")
+      assert "https://example.test/ext/passport" in activated
+      assert "https://example.test/ext/timestamp" in activated
+    end
+  end
+
+  describe "multiple required extensions" do
+    setup %{agent: agent} do
+      defmodule RequiredA do
+        @moduledoc false
+        @behaviour A2A.Extension
+        def declaration(_),
+          do: %A2A.AgentExtension{uri: "https://example.test/ext/req-a", required: true}
+      end
+
+      defmodule RequiredB do
+        @moduledoc false
+        @behaviour A2A.Extension
+        def declaration(_),
+          do: %A2A.AgentExtension{uri: "https://example.test/ext/req-b", required: true}
+      end
+
+      opts = plug_opts(agent, extensions: [RequiredA, RequiredB])
+      {:ok, opts: opts}
+    end
+
+    test "fails when only one of two required is declared", %{opts: opts} do
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> Plug.Conn.put_req_header("a2a-extensions", "https://example.test/ext/req-a")
+        |> A2A.Plug.call(opts)
+
+      body = json_body(conn)
+      assert body["error"]["code"] == -32_008
+      assert body["error"]["data"] =~ "req-b"
+    end
+  end
+
+  describe "agent card advertises configured extensions" do
+    test "merges extension declarations into capabilities.extensions", %{agent: agent} do
+      opts = plug_opts(agent, extensions: [Timestamp, DataOnly])
+
+      conn =
+        Plug.Test.conn(:get, "/.well-known/agent-card.json")
+        |> A2A.Plug.call(opts)
+
+      assert conn.status == 200
+      card = json_body(conn)
+
+      assert [
+               %{
+                 "uri" => "https://example.test/ext/timestamp",
+                 "required" => false,
+                 "description" => "Adds timestamps"
+               },
+               %{
+                 "uri" => "https://example.test/ext/data-only",
+                 "required" => false,
+                 "description" => "Pure declaration, no hooks",
+                 "params" => %{"category" => "data-only"}
+               }
+             ] = card["capabilities"]["extensions"]
+    end
+
+    test "does not duplicate when agent_card_opts already declared the URI", %{agent: agent} do
+      pre_declared = %A2A.AgentExtension{
+        uri: "https://example.test/ext/timestamp",
+        description: "Pre-existing",
+        required: true
+      }
+
+      opts =
+        plug_opts(agent,
+          extensions: [Timestamp],
+          agent_card_opts: [capabilities: %{extensions: [pre_declared]}]
+        )
+
+      conn =
+        Plug.Test.conn(:get, "/.well-known/agent-card.json")
+        |> A2A.Plug.call(opts)
+
+      card = json_body(conn)
+      # Pre-existing declaration wins; Timestamp not duplicated
+      assert card["capabilities"]["extensions"] == [
+               %{
+                 "uri" => "https://example.test/ext/timestamp",
+                 "required" => true,
+                 "description" => "Pre-existing"
+               }
+             ]
+    end
+  end
+
+  describe "extension activations surface to agent context" do
+    defmodule ExtAwareAgent do
+      @moduledoc false
+      use A2A.Agent, name: "ext-aware", skills: []
+
+      @impl A2A.Agent
+      def handle_message(_message, context) do
+        activated = Map.keys(context.extensions) |> Enum.sort()
+        {:reply, [A2A.Part.Text.new(Enum.join(activated, ","))]}
+      end
+    end
+
+    test "handle_message sees activations keyed by URI" do
+      agent = start_supervised!({ExtAwareAgent, [name: nil]})
+      opts = plug_opts(agent, extensions: [Timestamp, DataOnly])
+
+      conn =
+        json_rpc_conn("message/send", message_params())
+        |> Plug.Conn.put_req_header(
+          "a2a-extensions",
+          "https://example.test/ext/timestamp, https://example.test/ext/data-only"
+        )
+        |> A2A.Plug.call(opts)
+
+      task = json_body(conn)["result"]["task"]
+      [%{"parts" => [%{"text" => text}]}] = task["artifacts"]
+
+      assert text ==
+               Enum.join(
+                 [
+                   "https://example.test/ext/data-only",
+                   "https://example.test/ext/timestamp"
+                 ],
+                 ","
+               )
+    end
+  end
+end

--- a/test/support/extensions.ex
+++ b/test/support/extensions.ex
@@ -1,0 +1,77 @@
+defmodule A2A.Test.Extensions.Timestamp do
+  @moduledoc false
+  @behaviour A2A.Extension
+
+  @uri "https://example.test/ext/timestamp"
+
+  @impl true
+  def declaration(_state) do
+    %A2A.AgentExtension{uri: @uri, description: "Adds timestamps"}
+  end
+
+  @impl true
+  def activate(_requested, _ctx, _state) do
+    {:ok, %{started_at: 1_700_000_000_000}}
+  end
+
+  @impl true
+  def handle_request(message, params, state) do
+    message = A2A.Extension.put_metadata(message, __MODULE__, %{seen_at: state.started_at})
+    {:ok, message, params, state}
+  end
+
+  @impl true
+  def handle_response(task, _params, state) do
+    task = A2A.Extension.put_metadata(task, __MODULE__, %{finished_at: state.started_at})
+    {:ok, task, state}
+  end
+end
+
+defmodule A2A.Test.Extensions.Passport do
+  @moduledoc false
+  @behaviour A2A.Extension
+
+  @uri "https://example.test/ext/passport"
+
+  @impl true
+  def init(opts), do: Keyword.get(opts, :issuer, "default")
+
+  @impl true
+  def declaration(_state) do
+    %A2A.AgentExtension{uri: @uri, required: true, description: "Passport"}
+  end
+
+  @impl true
+  def activate(_requested, _ctx, issuer), do: {:ok, %{issuer: issuer}}
+end
+
+defmodule A2A.Test.Extensions.SkipMe do
+  @moduledoc false
+  @behaviour A2A.Extension
+
+  @uri "https://example.test/ext/skip"
+
+  @impl true
+  def declaration(_state) do
+    %A2A.AgentExtension{uri: @uri, description: "Always skips"}
+  end
+
+  @impl true
+  def activate(_requested, _ctx, _state), do: :skip
+end
+
+defmodule A2A.Test.Extensions.DataOnly do
+  @moduledoc false
+  @behaviour A2A.Extension
+
+  @uri "https://example.test/ext/data-only"
+
+  @impl true
+  def declaration(_state) do
+    %A2A.AgentExtension{
+      uri: @uri,
+      description: "Pure declaration, no hooks",
+      params: %{"category" => "data-only"}
+    }
+  end
+end


### PR DESCRIPTION
## Summary

Adds A2A v1.0 extension support: behaviour, header negotiation, agent-card advertisement, and a reference extension.

## Type of change

- [x] New feature
- [x] Documentation

## What changed

- `A2A.Extension` behaviour with `declaration/1`, `activate/3`, `handle_request/3`, `handle_response/3` (all but declaration optional)
- `A2A.AgentExtension` struct for declarations; merged into `AgentCard.capabilities.extensions`
- `A2A.Plug` `:extensions` option — parses `A2A-Extensions` header, enforces required (-32008), runs middleware chain, sets response header
- `A2A.Client.new/2` `:extensions` option — advertises URIs in request header; `parse_extensions_header/1` + `activated/2` helpers
- `context.extensions` map surfaced to `handle_message/2`; `A2A.Extension.fetch/2`, `activated?/2`, `put_metadata/3` helpers
- `A2A.Extension.Timestamp` shipped as in-tree reference
- `examples/extensions.exs` runnable end-to-end demo
- README, CHANGELOG, SPEC.md, and `A2A.Extension` moduledoc updated

## Out of scope (deferred)

- Method-extension dispatch (`methods/1`, `handle_method/3`)
- State-machine extensions
- Agent-macro registration (`use A2A.Agent, extensions: [...]`)

Part of #13.

## Test plan

- [x] `mix test` — 452 tests, 0 failures
- [x] `mix credo --strict` — clean
- [x] `mix dialyzer` — clean
- [x] `mix run examples/extensions.exs` — full round-trip succeeds
- [x] `mix docs` — Extension module + Timestamp reference render