### PR TITLE
feat(version): add A2A-Version header negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `capabilities.extensions`; `context.extensions` map for agents to read
   per-request activations; `A2A.Extension.Timestamp` as a reference
   implementation.
+- A2A v1.0 `A2A-Version` header negotiation: `A2A.Version` helper module;
+  `A2A.Plug` `:versions` option (defaults to `["0.3", "1.0"]`) validates
+  the request header and returns `VersionNotSupportedError` (-32009) for
+  unsupported versions; negotiated version echoed in the response header.
+  `A2A.Client` `:version` option (defaults to `"1.0"`) sets the request
+  header on every call; `A2A.Client.version/1` reads the server's
+  echoed value. Missing/empty headers are interpreted as `"0.3"`
+  (spec §3.6.2) and only `Major.Minor` is significant.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A2A gives you behaviour-based agents that run as GenServer processes. Define an 
 - **Supervision** — `A2A.AgentSupervisor` starts a fleet of agents with one call
 - **Pluggable storage** — `A2A.TaskStore` behaviour with built-in ETS implementation
 - **Protocol extensions** — A2A v1.0 `A2A-Extensions` header negotiation; ship your own `A2A.Extension` modules or use the bundled `A2A.Extension.Timestamp`
+- **Protocol versioning** — A2A v1.0 `A2A-Version` header negotiation; server accepts `0.3` and `1.0` by default and returns `VersionNotSupportedError` (-32009) for others, client sends `1.0` on every request
 - **Telemetry** — `:telemetry` spans and events for calls, messages, cancels, and state transitions
 
 ## Quick Start

--- a/SPEC.md
+++ b/SPEC.md
@@ -104,17 +104,17 @@ library only supports JSON-RPC. Full implementation requires:
 
 ### Version & Wire Format Negotiation
 
-Our implementation is hardcoded to A2A v0.3. The spec supports version
-selection and wire format options negotiated via HTTP headers. Would require:
+The server accepts both A2A v0.3 and v1.0 wire formats and method names,
+and the `A2A-Version` header is parsed and validated per spec §3.6
+(unsupported versions return `VersionNotSupportedError` -32009). Still
+outstanding:
 
-- `a2a-version` header parsing and validation on the server — reject
-  unsupported versions with an appropriate error
-- Version-aware encoding/decoding in `A2A.JSON` (field names and structure
-  may differ between spec versions)
+- Per-interface version selection from `supportedInterfaces[]` — agents
+  exposing multiple interfaces at different URLs with different versions
 - Wire format option (`spec_json` vs `proto_json`) controlling field naming
   conventions (camelCase vs snake_case)
-- Client sends version header; server validates compatibility and responds
-  with the negotiated version
+- Query-parameter fallback (`?A2A-Version=…`) — spec §3.6.1 says clients
+  MAY use it instead of the header
 
 ### Task Resubscribe Streaming
 

--- a/lib/a2a/client.ex
+++ b/lib/a2a/client.ex
@@ -45,6 +45,13 @@ if Code.ensure_loaded?(Req) do
     request header on every call. Use `parse_extensions_header/1` and
     `activated/2` on the resulting `Req.Response` to find out which
     extensions the server activated.
+
+    ## Protocol version
+
+    Pass `:version` to `new/2` to set the `A2A-Version` request header
+    sent on every call. Defaults to `A2A.Version.default/0` (`"1.0"`).
+    Use `version/1` on a `Req.Response` to read the version the server
+    echoed back.
     """
 
     alias A2A.JSONRPC.Error
@@ -79,13 +86,17 @@ if Code.ensure_loaded?(Req) do
 
     def new(url, opts) when is_binary(url) do
       {ext_entries, opts} = Keyword.pop(opts, :extensions, [])
+      {version, opts} = Keyword.pop(opts, :version, A2A.Version.default())
       compiled = A2A.Extension.compile(ext_entries)
       ext_uris = A2A.Extension.declared_uris(compiled)
 
       {req_opts, _rest} =
         Keyword.split(opts, [:headers, :connect_options, :retry, :plug])
 
-      base_headers = [{"content-type", "application/json"}]
+      base_headers = [
+        {"content-type", "application/json"},
+        {"a2a-version", version}
+      ]
 
       base_headers =
         case ext_uris do
@@ -275,6 +286,20 @@ if Code.ensure_loaded?(Req) do
       |> Enum.flat_map(&String.split(&1, ","))
       |> Enum.map(&String.trim/1)
       |> Enum.reject(&(&1 == ""))
+    end
+
+    @doc """
+    Returns the negotiated A2A protocol version from the server's
+    `A2A-Version` response header, or `nil` if the header is absent.
+    """
+    @spec version(Req.Response.t()) :: String.t() | nil
+    def version(%Req.Response{headers: headers}) do
+      case Map.get(headers, "a2a-version") do
+        nil -> nil
+        [] -> nil
+        [v | _] when is_binary(v) -> v
+        v when is_binary(v) -> v
+      end
     end
 
     @doc """

--- a/lib/a2a/plug.ex
+++ b/lib/a2a/plug.ex
@@ -44,6 +44,13 @@ if Code.ensure_loaded?(Plug) do
       `A2A-Extensions` response header to the URIs that were activated.
       Declarations are merged into `capabilities.extensions` on the
       served agent card.
+    - `:versions` — list of supported A2A protocol versions as
+      `Major.Minor` strings (default: `A2A.Version.supported_default/0`,
+      currently `["0.3", "1.0"]`). The client's `A2A-Version` header is
+      normalized to `Major.Minor` and validated against this list;
+      unsupported versions return `VersionNotSupportedError` (-32009).
+      Missing/empty headers are treated as `"0.3"` (spec §3.6.2). The
+      negotiated version is echoed in the `A2A-Version` response header.
 
     ## Per-Request Overrides
 
@@ -130,7 +137,8 @@ if Code.ensure_loaded?(Plug) do
         agent_card_opts: Keyword.get(opts, :agent_card_opts, []),
         metadata: Keyword.get(opts, :metadata, %{}),
         authorize_task: Keyword.get(opts, :authorize_task),
-        extensions: A2A.Extension.compile(Keyword.get(opts, :extensions, []))
+        extensions: A2A.Extension.compile(Keyword.get(opts, :extensions, [])),
+        versions: Keyword.get(opts, :versions, A2A.Version.supported_default())
       }
     end
 
@@ -217,14 +225,26 @@ if Code.ensure_loaded?(Plug) do
     # -- JSON-RPC dispatch -----------------------------------------------------
 
     defp handle_json_rpc(conn, opts) do
+      version = A2A.Version.parse_header(get_req_header(conn, "a2a-version"))
       requested = A2A.Extension.parse_header(get_req_header(conn, "a2a-extensions"))
 
-      with :ok <- A2A.Extension.validate_required(opts.extensions, requested),
+      with :ok <- A2A.Version.validate(version, opts.versions),
+           :ok <- A2A.Extension.validate_required(opts.extensions, requested),
            {:ok, activations, activated_uris} <-
              A2A.Extension.activate(opts.extensions, requested, %{conn: conn}) do
-        conn = put_extensions_response_header(conn, activated_uris)
+        conn =
+          conn
+          |> put_resp_header("a2a-version", version)
+          |> put_extensions_response_header(activated_uris)
+
         dispatch_json_rpc(conn, opts, activations)
       else
+        {:error, rejected} when is_binary(rejected) ->
+          send_json(
+            conn,
+            Response.error(nil, Error.version_not_supported(rejected))
+          )
+
         {:error, missing} when is_list(missing) ->
           send_json(
             conn,

--- a/lib/a2a/version.ex
+++ b/lib/a2a/version.ex
@@ -1,0 +1,68 @@
+defmodule A2A.Version do
+  @moduledoc """
+  Helpers for the `A2A-Version` HTTP header (A2A v1.0 spec §3.6).
+
+  Versions are negotiated as `Major.Minor` strings. Patch components are
+  not significant and are stripped during normalization. Per spec §3.6.2
+  an empty or missing version is interpreted as `"0.3"`.
+  """
+
+  @default "1.0"
+  @supported_default ["0.3", "1.0"]
+
+  @doc "Default version a client sends in the `A2A-Version` request header."
+  @spec default() :: String.t()
+  def default, do: @default
+
+  @doc "Default list of versions a server accepts."
+  @spec supported_default() :: [String.t()]
+  def supported_default, do: @supported_default
+
+  @doc """
+  Normalizes a version string to its `Major.Minor` form.
+
+  - `nil` and `""` → `"0.3"` (per spec §3.6.2)
+  - `"1.0.3"` → `"1.0"`
+  - `"  0.3  "` → `"0.3"`
+
+  Values that can't be parsed as `Major.Minor` are returned trimmed so the
+  caller can include them in an error response.
+  """
+  @spec normalize(String.t() | nil) :: String.t()
+  def normalize(nil), do: "0.3"
+  def normalize(""), do: "0.3"
+
+  def normalize(version) when is_binary(version) do
+    case String.trim(version) do
+      "" ->
+        "0.3"
+
+      trimmed ->
+        case Regex.run(~r/^(\d+)\.(\d+)/, trimmed) do
+          [_, major, minor] -> major <> "." <> minor
+          _ -> trimmed
+        end
+    end
+  end
+
+  @doc """
+  Parses a Plug-style header value (list of strings, single string, or nil)
+  into a normalized `Major.Minor` version. An empty list or missing value
+  becomes `"0.3"`.
+  """
+  @spec parse_header([String.t()] | String.t() | nil) :: String.t()
+  def parse_header(nil), do: "0.3"
+  def parse_header([]), do: "0.3"
+  def parse_header(value) when is_binary(value), do: normalize(value)
+  def parse_header([value | _]) when is_binary(value), do: normalize(value)
+
+  @doc """
+  Returns `:ok` when `version` is in the supported list, otherwise
+  `{:error, version}` with the rejected value so the caller can surface it
+  in a `VersionNotSupportedError`.
+  """
+  @spec validate(String.t(), [String.t()]) :: :ok | {:error, String.t()}
+  def validate(version, supported) when is_binary(version) and is_list(supported) do
+    if version in supported, do: :ok, else: {:error, version}
+  end
+end

--- a/test/a2a/client_version_test.exs
+++ b/test/a2a/client_version_test.exs
@@ -1,0 +1,78 @@
+defmodule A2A.ClientVersionTest do
+  use ExUnit.Case, async: true
+
+  alias A2A.Client
+
+  @task_json %{
+    "kind" => "task",
+    "id" => "tsk-1",
+    "status" => %{"state" => "TASK_STATE_COMPLETED"},
+    "history" => [
+      %{"messageId" => "m1", "role" => "ROLE_USER", "parts" => [%{"text" => "hi"}]},
+      %{"messageId" => "m2", "role" => "ROLE_AGENT", "parts" => [%{"text" => "ok"}]}
+    ],
+    "artifacts" => [%{"parts" => [%{"text" => "ok"}]}]
+  }
+
+  defp jsonrpc_success(result, id \\ 1) do
+    %{"jsonrpc" => "2.0", "id" => id, "result" => result}
+  end
+
+  defp json_resp(conn, status, body, headers \\ []) do
+    conn =
+      Enum.reduce(headers, conn, fn {k, v}, c -> Plug.Conn.put_resp_header(c, k, v) end)
+
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(status, Jason.encode!(body))
+  end
+
+  describe "new/2 :version option" do
+    test "sends A2A-Version: 1.0 by default" do
+      received = self()
+
+      plug = fn conn ->
+        send(received, {:headers, conn.req_headers})
+        json_resp(conn, 200, jsonrpc_success(%{"task" => @task_json}))
+      end
+
+      client = Client.new("https://agent.example.com", plug: plug)
+      assert {:ok, _task} = Client.send_message(client, "hi")
+
+      assert_received {:headers, headers}
+      assert {"a2a-version", "1.0"} in headers
+    end
+
+    test "honors an explicit :version" do
+      received = self()
+
+      plug = fn conn ->
+        send(received, {:headers, conn.req_headers})
+        json_resp(conn, 200, jsonrpc_success(%{"task" => @task_json}))
+      end
+
+      client = Client.new("https://agent.example.com", version: "0.3", plug: plug)
+      assert {:ok, _task} = Client.send_message(client, "hi")
+
+      assert_received {:headers, headers}
+      assert {"a2a-version", "0.3"} in headers
+    end
+  end
+
+  describe "version/1 response helper" do
+    test "reads the server's negotiated version" do
+      response = %Req.Response{headers: %{"a2a-version" => ["1.0"]}}
+      assert Client.version(response) == "1.0"
+    end
+
+    test "returns nil when header is absent" do
+      response = %Req.Response{headers: %{}}
+      assert Client.version(response) == nil
+    end
+
+    test "accepts a bare string header value" do
+      response = %Req.Response{headers: %{"a2a-version" => "0.3"}}
+      assert Client.version(response) == "0.3"
+    end
+  end
+end

--- a/test/a2a/plug_version_test.exs
+++ b/test/a2a/plug_version_test.exs
@@ -1,0 +1,169 @@
+defmodule A2A.PlugVersionTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :plug
+
+  defp plug_opts(agent, extra \\ []) do
+    A2A.Plug.init([agent: agent, base_url: "http://localhost:4000"] ++ extra)
+  end
+
+  defp json_rpc_conn(method, params) do
+    body =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "id" => 1,
+        "method" => method,
+        "params" => params
+      })
+
+    Plug.Test.conn(:post, "/", body)
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+  end
+
+  defp message_params do
+    %{
+      "message" => %{
+        "messageId" => "msg-test",
+        "role" => "user",
+        "parts" => [%{"kind" => "text", "text" => "hi"}]
+      }
+    }
+  end
+
+  defp send_message(opts, version_header \\ :unset) do
+    conn = json_rpc_conn("message/send", message_params())
+
+    conn =
+      case version_header do
+        :unset -> conn
+        nil -> conn
+        value -> Plug.Conn.put_req_header(conn, "a2a-version", value)
+      end
+
+    A2A.Plug.call(conn, opts)
+  end
+
+  defp json_body(conn), do: Jason.decode!(conn.resp_body)
+  defp get_resp_header(conn, key), do: for({k, v} <- conn.resp_headers, k == key, do: v)
+
+  setup do
+    agent = start_supervised!({A2A.Test.EchoAgent, [name: nil]})
+    {:ok, agent: agent}
+  end
+
+  describe "default supported versions" do
+    setup %{agent: agent}, do: {:ok, opts: plug_opts(agent)}
+
+    test "accepts 1.0", %{opts: opts} do
+      conn = send_message(opts, "1.0")
+      assert conn.status == 200
+      assert json_body(conn)["result"]
+      assert get_resp_header(conn, "a2a-version") == ["1.0"]
+    end
+
+    test "accepts 0.3", %{opts: opts} do
+      conn = send_message(opts, "0.3")
+      assert conn.status == 200
+      assert get_resp_header(conn, "a2a-version") == ["0.3"]
+    end
+
+    test "treats missing header as 0.3", %{opts: opts} do
+      conn = send_message(opts)
+      assert conn.status == 200
+      assert get_resp_header(conn, "a2a-version") == ["0.3"]
+    end
+
+    test "treats empty header as 0.3", %{opts: opts} do
+      conn = send_message(opts, "")
+      assert conn.status == 200
+      assert get_resp_header(conn, "a2a-version") == ["0.3"]
+    end
+
+    test "strips patch components before validating", %{opts: opts} do
+      conn = send_message(opts, "1.0.3")
+      assert conn.status == 200
+      assert get_resp_header(conn, "a2a-version") == ["1.0"]
+    end
+
+    test "rejects an unknown version with -32009", %{opts: opts} do
+      conn = send_message(opts, "9.9")
+      body = json_body(conn)
+      assert body["error"]["code"] == -32_009
+      assert body["error"]["data"] == "9.9"
+      assert get_resp_header(conn, "a2a-version") == []
+    end
+
+    test "rejects garbage values with -32009", %{opts: opts} do
+      conn = send_message(opts, "abc")
+      body = json_body(conn)
+      assert body["error"]["code"] == -32_009
+      assert body["error"]["data"] == "abc"
+    end
+  end
+
+  describe "custom :versions list" do
+    test "narrows acceptance", %{agent: agent} do
+      opts = plug_opts(agent, versions: ["1.0"])
+
+      ok = send_message(opts, "1.0")
+      assert ok.status == 200
+
+      bad = send_message(opts, "0.3")
+      body = json_body(bad)
+      assert body["error"]["code"] == -32_009
+      assert body["error"]["data"] == "0.3"
+    end
+
+    test "also rejects the missing-header 0.3 default when 0.3 is unsupported",
+         %{agent: agent} do
+      opts = plug_opts(agent, versions: ["1.0"])
+      conn = send_message(opts)
+      body = json_body(conn)
+      assert body["error"]["code"] == -32_009
+      assert body["error"]["data"] == "0.3"
+    end
+  end
+
+  describe "streaming requests" do
+    test "version is validated on SendStreamingMessage", %{agent: agent} do
+      opts = plug_opts(agent)
+
+      body =
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => 1,
+          "method" => "SendStreamingMessage",
+          "params" => message_params()
+        })
+
+      conn =
+        Plug.Test.conn(:post, "/", body)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_req_header("a2a-version", "9.9")
+        |> A2A.Plug.call(opts)
+
+      assert json_body(conn)["error"]["code"] == -32_009
+    end
+  end
+
+  describe "ordering vs extensions" do
+    setup %{agent: agent} do
+      defmodule RequiredExt do
+        @moduledoc false
+        @behaviour A2A.Extension
+        def declaration(_),
+          do: %A2A.AgentExtension{uri: "https://example.test/ext/req-only", required: true}
+      end
+
+      opts = plug_opts(agent, extensions: [RequiredExt])
+      {:ok, opts: opts}
+    end
+
+    test "version is checked before required-extension validation", %{opts: opts} do
+      # Bad version + missing required extension → -32009 (version) wins
+      conn = send_message(opts, "9.9")
+      body = json_body(conn)
+      assert body["error"]["code"] == -32_009
+    end
+  end
+end

--- a/test/a2a/version_test.exs
+++ b/test/a2a/version_test.exs
@@ -1,0 +1,79 @@
+defmodule A2A.VersionTest do
+  use ExUnit.Case, async: true
+
+  alias A2A.Version
+
+  doctest A2A.Version
+
+  describe "default/0" do
+    test "returns the library's current version" do
+      assert Version.default() == "1.0"
+    end
+  end
+
+  describe "supported_default/0" do
+    test "accepts both 0.3 and 1.0" do
+      assert Version.supported_default() == ["0.3", "1.0"]
+    end
+  end
+
+  describe "normalize/1" do
+    test "treats nil and empty as 0.3" do
+      assert Version.normalize(nil) == "0.3"
+      assert Version.normalize("") == "0.3"
+      assert Version.normalize("   ") == "0.3"
+    end
+
+    test "passes Major.Minor through unchanged" do
+      assert Version.normalize("1.0") == "1.0"
+      assert Version.normalize("0.3") == "0.3"
+    end
+
+    test "strips patch components" do
+      assert Version.normalize("1.0.3") == "1.0"
+      assert Version.normalize("0.3.0") == "0.3"
+    end
+
+    test "trims surrounding whitespace" do
+      assert Version.normalize("  1.0  ") == "1.0"
+    end
+
+    test "passes garbage through trimmed for the error path" do
+      assert Version.normalize("abc") == "abc"
+      assert Version.normalize("1") == "1"
+    end
+  end
+
+  describe "parse_header/1" do
+    test "missing or empty returns 0.3" do
+      assert Version.parse_header(nil) == "0.3"
+      assert Version.parse_header([]) == "0.3"
+      assert Version.parse_header([""]) == "0.3"
+    end
+
+    test "normalizes the first value from a Plug header list" do
+      assert Version.parse_header(["1.0"]) == "1.0"
+      assert Version.parse_header(["1.0.3"]) == "1.0"
+    end
+
+    test "accepts a bare string" do
+      assert Version.parse_header("0.3") == "0.3"
+    end
+  end
+
+  describe "validate/2" do
+    test "returns :ok for supported versions" do
+      assert Version.validate("1.0", ["0.3", "1.0"]) == :ok
+      assert Version.validate("0.3", ["0.3", "1.0"]) == :ok
+    end
+
+    test "returns {:error, version} for unsupported" do
+      assert Version.validate("9.9", ["0.3", "1.0"]) == {:error, "9.9"}
+      assert Version.validate("abc", ["0.3", "1.0"]) == {:error, "abc"}
+    end
+
+    test "honors a narrowed supported list" do
+      assert Version.validate("0.3", ["1.0"]) == {:error, "0.3"}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds A2A v1.0 `A2A-Version` header parsing and validation on the server, and emission on the client. Part of #13.

## Type of change

- [x] New feature
- [x] Documentation

## What changed

- `A2A.Version` helper module — `default/0`, `supported_default/0`, `normalize/1`, `parse_header/1`, `validate/2`. Missing/empty → `"0.3"` (spec §3.6.2); patch components stripped; `Major.Minor` only is significant.
- `A2A.Plug` `:versions` option (default `["0.3", "1.0"]`) — validates the request header before extension negotiation and returns `VersionNotSupportedError` (-32009) for unsupported values. Negotiated version echoed in the `A2A-Version` response header. Streaming covered via the same path.
- `A2A.Client.new/2` `:version` option (default `"1.0"`) — sets the request header on every call. `A2A.Client.version/1` reads the server's echoed value.
- README, CHANGELOG, SPEC.md, and Plug/Client moduledocs updated.

## Out of scope (deferred)

- Query-parameter fallback (`?A2A-Version=…`) — spec §3.6.1 says clients MAY use it instead of the header
- Per-interface version selection from `supportedInterfaces[]`
- Wire format option (`spec_json` vs `proto_json`)

Part of #13.

## Test plan

- [x] `mix test` — 494 tests, 0 failures (29 new)
- [x] `mix quality` — credo + dialyzer clean
- [x] Server rejects `9.9` with -32009; accepts `0.3`, `1.0`, `1.0.3` (normalized); treats missing/empty as `0.3`
- [x] Client sends `A2A-Version: 1.0` by default, honors `:version` override, reads server echo via `version/1`
- [x] Version check runs before extension validation (bad version + missing required ext → -32009, not -32008)