### PR TITLE
ci: add Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,79 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude-review:
+    if: >
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.event.comment.body == '/review')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Checkout PR branch (comment trigger)
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr checkout ${{ github.event.issue.number }}
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            Review this PR. Read REVIEW.md at the repo root for files/paths to skip.
+
+            Before commenting, read all existing review comments and conversations
+            on this PR to avoid repeating prior feedback.
+
+            ## What to comment on (ONLY these)
+
+            - Bugs or logic errors that would cause incorrect behavior
+            - Security vulnerabilities
+            - Breaking changes to public APIs
+
+            ## What NOT to comment on
+
+            - Style, formatting, or naming — CI runs `mix format` and `mix credo --strict`
+            - Minor refactoring or cleanup suggestions
+            - Anything a linter or formatter would catch
+            - "Consider" or "you might want to" suggestions
+            - Test coverage gaps (unless a bug is untested)
+
+            ## Confidence scoring
+
+            For each potential issue, internally rate your confidence from 1-10.
+            Only post issues you rate 8/10 or higher. If unsure, skip it.
+
+            ## Output rules
+
+            - Maximum 5 inline comments total
+            - Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) for specific code issues
+            - Use `gh pr comment` for a top-level summary
+            - If no issues meet the criteria above, post a single summary comment:
+              "Reviewed — no high-confidence issues found. LGTM."
+            - Only post GitHub comments — don't submit review text as messages
+          # TODO: disable after tuning — logs all Claude messages including tool results
+          show_full_output: true
+          claude_args: >-
+            --max-turns 15
+            --allowedTools "Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment"

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,18 @@
+# Review Exclusions
+
+Files and paths that automated reviewers should skip.
+
+## Skip these files
+
+- `mix.lock` — dependency lock file, not human-authored
+- `priv/plts/` — Dialyzer PLT cache (generated)
+- `.formatter.exs` — formatter config, rarely meaningful to review
+- `.github/workflows/` — CI configs, reviewed manually
+- `examples/` — demo/example code, not part of the library
+- `test/tck/` — TCK harness scaffolding, reviewed manually
+
+## Skip these patterns
+
+- Documentation-only changes (`*.md` files, `@moduledoc`/`@doc` edits)
+- Dependency version bumps with no code changes
+- Test fixture data files


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-code-review.yml` — runs on PR open/ready and on `/review` comments
- Adds `REVIEW.md` listing files/paths the reviewer should skip

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / chore
- [ ] Documentation