### PR TITLE
ci: group dependabot updates into weekly batches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,27 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      dev-dependencies:
+        patterns:
+          - "ex_doc"
+          - "credo"
+          - "dialyxir"
+        update-types: ["patch", "minor"]
+      runtime-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "ex_doc"
+          - "credo"
+          - "dialyxir"
+        update-types: ["patch", "minor"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Bundle weekly Dependabot bumps into grouped PRs (dev-dependencies, runtime-dependencies, actions) instead of one PR per package, matching a2ui-elixir's setup.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / chore
- [ ] Documentation