### PR TITLE
fix: translate :timeout to :receive_timeout in discover/2

### DIFF
--- a/lib/a2a/client.ex
+++ b/lib/a2a/client.ex
@@ -138,9 +138,12 @@ if Code.ensure_loaded?(Req) do
       path = Keyword.get(opts, :agent_card_path, "/.well-known/agent-card.json")
       req_opts = take_req_opts(opts)
 
-      base_opts = [base_url: base_url]
-
-      req = Req.new(Keyword.merge(base_opts, req_opts))
+      # Route options through merge_req_opts/2 rather than passing them
+      # straight to Req.new/1: it translates :timeout into Req's
+      # :receive_timeout (Req has no :timeout option), matching how the
+      # message-send functions handle it and keeping the :timeout option
+      # documented on discover/2 working consistently.
+      req = merge_req_opts(Req.new(base_url: base_url), req_opts)
 
       case Req.get(req, url: path) do
         {:ok, %Req.Response{status: 200, body: body}} when is_map(body) ->

--- a/test/a2a/client_test.exs
+++ b/test/a2a/client_test.exs
@@ -92,6 +92,17 @@ defmodule A2A.ClientTest do
       assert {:error, {:unexpected_status, 404}} =
                Client.discover("https://agent.example.com", plug: plug)
     end
+
+    test "accepts the :timeout option without raising" do
+      plug = fn conn ->
+        json_resp(conn, 200, @agent_card_json)
+      end
+
+      # :timeout must be translated to Req's :receive_timeout; passing it
+      # straight to Req.new/1 raises "unknown option :timeout".
+      assert {:ok, %AgentCard{name: "test-agent"}} =
+               Client.discover("https://agent.example.com", plug: plug, timeout: 60_000)
+    end
   end
 
   # -------------------------------------------------------------------


### PR DESCRIPTION
Fixes #58 — see that issue for full context, root cause, and reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)