### PR TITLE
fix: set taskId/contextId on the message in send params

### DIFF
--- a/lib/a2a/client.ex
+++ b/lib/a2a/client.ex
@@ -363,7 +363,7 @@ if Code.ensure_loaded?(Req) do
 
     defp build_send_params(message, opts) do
       req_opts = take_req_opts(opts)
-      msg = normalize_message(message)
+      msg = message |> normalize_message() |> put_message_ids(opts)
       {:ok, encoded_msg} = A2A.JSON.encode(msg)
 
       params =
@@ -374,6 +374,18 @@ if Code.ensure_loaded?(Req) do
         |> put_opt("metadata", opts[:metadata])
 
       {params, req_opts}
+    end
+
+    # The A2A spec carries `taskId`/`contextId` on the Message. Some servers
+    # (e.g. the reference JS SDK) read them only from the message and ignore the
+    # top-level params, so mirror the options onto the message struct. An id set
+    # explicitly on the struct takes precedence over the option.
+    defp put_message_ids(%A2A.Message{} = msg, opts) do
+      %{
+        msg
+        | task_id: msg.task_id || opts[:task_id],
+          context_id: msg.context_id || opts[:context_id]
+      }
     end
 
     defp normalize_message(%A2A.Message{} = msg), do: msg

--- a/test/a2a/client_test.exs
+++ b/test/a2a/client_test.exs
@@ -135,6 +135,10 @@ defmodule A2A.ClientTest do
         assert decoded["params"]["id"] == "tsk-existing"
         assert decoded["params"]["contextId"] == "ctx-42"
 
+        # Spec-compliant servers read the ids from the message itself.
+        assert decoded["params"]["message"]["taskId"] == "tsk-existing"
+        assert decoded["params"]["message"]["contextId"] == "ctx-42"
+
         json_resp(conn, 200, jsonrpc_success(%{"task" => @task_json}))
       end
 


### PR DESCRIPTION
## What

`A2A.Client.send_message/3` and `stream_message/3` set `:task_id` /
`:context_id` only at the JSON-RPC params top level and never on the `Message`.
Per the A2A spec, `taskId` / `contextId` are fields of the `Message`, and
spec-compliant servers read them from `params.message`. This PR mirrors the
options onto the `Message` struct in `build_send_params/2` before encoding, so
they serialize as `message.taskId` / `message.contextId`.

An id set explicitly on a passed-in `Message` struct takes precedence over the
option. The existing top-level params are retained, so this is fully
backward-compatible with the current lenient `A2A.Plug` server.

## Why

Against a server that reads the ids only from the message — e.g. the reference
JS SDK `@a2a-js/sdk`, whose handler does
`const contextId = incomingMessage.contextId || task?.contextId || uuidv4()` —
the client-supplied `contextId` was invisible, so the server minted a new
context per request and multi-turn continuity was lost. Elixir-to-Elixir setups
were unaffected only because `A2A.Plug` reads the top-level params as a
fallback, which masked the bug.

## Testing

- Extended `test/a2a/client_test.exs` "sends message with task_id and
  context_id" to assert the ids appear on `params.message` as well as the
  top-level params.
- `mix test` — 2 doctests, 525 tests, 0 failures.
- `mix format --check-formatted` — clean.

Fixes #62
